### PR TITLE
Address adversarial audio enhancement review

### DIFF
--- a/.agents/skills/auto-enhancement/references/auto-enhance-workflow.md
+++ b/.agents/skills/auto-enhancement/references/auto-enhance-workflow.md
@@ -67,7 +67,7 @@ Read these surfaces before accepting a result:
 - `stages`: terminal status, reason, exact operations, component evaluations, and resolved transitions.
 - `measurements.before`, `measurements.predicted`, and `measurements.after`: program and regional verification using stable region IDs.
 - `adjustments`: resolved user- or agent-authorized operations.
-- `resolved_operations_sha256`, source hash, and output hash: reproducibility surfaces.
+- `resolved_operations_sha256`, source hash, and output hash: reproducibility surfaces. The resolved-operations hash covers the pre-encode processing plan; render-only verification diagnostics such as codec peak correction remain explicit report fields but do not change that plan hash.
 
 ## Render verification
 

--- a/src/audio_cli/dsp.py
+++ b/src/audio_cli/dsp.py
@@ -362,6 +362,13 @@ def _detect_machine_regions(
     # speech reference; quiet/ambiguous events remain canonical and unmodified.
     threshold = max(noise_floor + 15.0, speech_reference_dbfs + 3.0, -55.0)
     candidates = (~speech_frames) & (levels >= threshold)
+    speech_sample_spans = [
+        (
+            max(0, round(region.start * sample_rate)),
+            min(audio.shape[0], round(region.end * sample_rate)),
+        )
+        for region in speech_regions
+    ]
 
     # Close gaps up to 200 ms so one sound with internal decay remains one stable region.
     max_gap_frames = 2
@@ -387,6 +394,10 @@ def _detect_machine_regions(
         if level < noise_floor + 8.0:
             continue
         region_id = f"machine_audio_{len(regions) + 1:03d}"
+        overlaps_speech = any(
+            start < speech_end and end > speech_start
+            for speech_start, speech_end in speech_sample_spans
+        )
         regions.append(
             MachineRegion(
                 region_id=region_id,
@@ -394,6 +405,7 @@ def _detect_machine_regions(
                 end=end / sample_rate,
                 measured_rms_dbfs=level,
                 difference_from_speech_db=level - speech_reference_dbfs,
+                overlaps_speech=overlaps_speech,
             )
         )
     return regions, noise_floor, threshold

--- a/src/audio_cli/pipeline.py
+++ b/src/audio_cli/pipeline.py
@@ -338,6 +338,12 @@ class EnhancementPipeline:
             )
             source_stage_report = _stage_result(stage, self.profile, result)
             stages.append(source_stage_report)
+        raw_abstained_regions = source_stage_report.get("abstained_regions", [])
+        abstained_source_region_ids = (
+            {str(region_id) for region_id in raw_abstained_regions}
+            if isinstance(raw_abstained_regions, list)
+            else set()
+        )
 
         current, fullband_adjustments = apply_fullband_adjustments(
             current,
@@ -475,6 +481,8 @@ class EnhancementPipeline:
                     corrections: dict[str, float] = {}
                     for measured_region in simulated_regional["machine_regions"]:
                         region_id = str(measured_region["region_id"])
+                        if region_id in abstained_source_region_ids:
+                            continue
                         difference = float(measured_region["difference_from_speech_db"])
                         if (
                             self.profile.machine_relative_minimum_lu
@@ -715,6 +723,15 @@ class EnhancementPipeline:
                     for measured_region in after_regional["machine_regions"]:
                         region_id = str(measured_region["region_id"])
                         difference = float(measured_region["difference_from_speech_db"])
+                        if region_id in abstained_source_region_ids:
+                            final_region_evaluations.append(
+                                {
+                                    "region_id": region_id,
+                                    "difference_from_speech_db": round(difference, 3),
+                                    "status": "abstained_overlap",
+                                }
+                            )
+                            continue
                         inside = (
                             self.profile.machine_relative_minimum_lu - 0.25
                             <= difference

--- a/src/audio_cli/pipeline.py
+++ b/src/audio_cli/pipeline.py
@@ -60,6 +60,46 @@ def _canonical_hash(payload: object) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _resolved_operations_hash(
+    profile: Profile,
+    stages: list[dict[str, object]],
+    adjustments: list[dict[str, object]],
+    source_sha256: object,
+) -> str:
+    stage_resolutions: list[dict[str, object]] = []
+    for stage in stages:
+        raw_operations = stage.get("operations", [])
+        operations: list[object] = []
+        if isinstance(raw_operations, list):
+            for operation in raw_operations:
+                if isinstance(operation, dict):
+                    operations.append(
+                        {
+                            key: value
+                            for key, value in operation.items()
+                            if key != "codec_peak_correction_db"
+                        }
+                    )
+                else:
+                    operations.append(operation)
+        stage_resolutions.append(
+            {
+                "name": stage.get("name"),
+                "status": stage.get("status"),
+                "reason": stage.get("reason"),
+                "operations": operations,
+            }
+        )
+    return _canonical_hash(
+        {
+            "profile": profile.as_dict(),
+            "stages": stage_resolutions,
+            "adjustments": adjustments,
+            "source_sha256": source_sha256,
+        }
+    )
+
+
 def _vad_audio(audio: np.ndarray, sample_rate: int) -> np.ndarray:
     mono = np.mean(audio, axis=1, dtype=np.float64).astype(np.float32)
     if sample_rate == 16_000:
@@ -594,13 +634,11 @@ class EnhancementPipeline:
                 "dry_run": dry_run,
                 "rendered": False,
             }
-            report["resolved_operations_sha256"] = _canonical_hash(
-                {
-                    "profile": self.profile.as_dict(),
-                    "stages": stages,
-                    "adjustments": resolved_adjustments,
-                    "source_sha256": source_info["sha256"],
-                }
+            report["resolved_operations_sha256"] = _resolved_operations_hash(
+                self.profile,
+                stages,
+                resolved_adjustments,
+                source_info["sha256"],
             )
             if dry_run:
                 return report
@@ -761,13 +799,11 @@ class EnhancementPipeline:
             report["timeline_preserved"] = timeline_ok
             report["dry_run"] = False
             report["rendered"] = True
-            report["resolved_operations_sha256"] = _canonical_hash(
-                {
-                    "profile": self.profile.as_dict(),
-                    "stages": stages,
-                    "adjustments": resolved_adjustments,
-                    "source_sha256": source_info["sha256"],
-                }
+            report["resolved_operations_sha256"] = _resolved_operations_hash(
+                self.profile,
+                stages,
+                resolved_adjustments,
+                source_info["sha256"],
             )
             return report
 

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -121,3 +121,29 @@ def test_voice_and_machine_balance_close_the_declared_gap() -> None:
     assert initial["machine_regions"][0]["difference_from_speech_db"] > 20
     difference = final["machine_regions"][0]["difference_from_speech_db"]
     assert -4.5 <= difference <= -1.5
+
+
+def test_machine_region_padding_that_reaches_speech_abstains() -> None:
+    sample_rate = 16_000
+    audio = np.zeros((sample_rate * 4, 2), dtype=np.float32)
+    machine = _sine(sample_rate, 0.5, 1000.0, 0.12)
+    speech_signal = _sine(sample_rate, 1.98, 220.0, 0.004)
+    audio[round(0.5 * sample_rate) : round(1.0 * sample_rate)] = machine[:, None]
+    audio[round(1.02 * sample_rate) : round(3.0 * sample_rate)] = speech_signal[:, None]
+    speech = [SpeechRegion(1.02, 3.0, 0.9, 1.0)]
+    profile = PROFILES["product-demo"]
+
+    analysis = analyze_signal(audio, sample_rate, speech, profile)
+
+    assert len(analysis.machine_regions) == 1
+    region = analysis.machine_regions[0]
+    assert region.end > speech[0].start
+    assert region.overlaps_speech is True
+
+    balanced, source_stage = apply_source_balance(audio, sample_rate, profile, analysis)
+
+    assert source_stage["status"] == "abstained"
+    assert source_stage["reason"] == "speech_and_machine_audio_overlap"
+    assert source_stage["abstained_regions"] == [region.region_id]
+    assert source_stage["operations"] == []
+    np.testing.assert_array_equal(balanced, audio)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -30,6 +30,7 @@ def test_end_to_end_wav_render_reports_every_stage(tmp_path) -> None:
     wavfile.write(source, sample_rate, audio)
 
     pipeline = EnhancementPipeline(PROFILES["product-demo"], detector=FakeVad())
+    dry_run_report = pipeline.run(source, output=None, dry_run=True)
     report = pipeline.run(source, output=output, dry_run=False)
 
     assert output.is_file()
@@ -43,3 +44,7 @@ def test_end_to_end_wav_render_reports_every_stage(tmp_path) -> None:
     )
     after_lufs = report["measurements"]["after"]["program"]["input_i"]
     assert abs(after_lufs - PROFILES["product-demo"].target_lufs) <= 0.6
+    assert (
+        report["resolved_operations_sha256"]
+        == dry_run_report["resolved_operations_sha256"]
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 from scipy.io import wavfile
 
+import audio_cli.pipeline as pipeline_module
 from audio_cli.pipeline import EnhancementPipeline
 from audio_cli.profiles import PROFILES, STAGE_ORDER
 from audio_cli.vad import SpeechRegion
@@ -47,4 +48,60 @@ def test_end_to_end_wav_render_reports_every_stage(tmp_path) -> None:
     assert (
         report["resolved_operations_sha256"]
         == dry_run_report["resolved_operations_sha256"]
+    )
+
+
+def test_pipeline_never_corrects_a_machine_region_that_overlaps_speech(
+    tmp_path, monkeypatch
+) -> None:
+    sample_rate = 48_000
+    duration = 4.0
+    time = np.arange(round(sample_rate * duration)) / sample_rate
+    audio = np.zeros((time.size, 2), dtype=np.float32)
+    isolated_machine = (time >= 0.3) & (time < 0.8)
+    adjacent_machine = (time >= 1.2) & (time < 1.5)
+    speech = (time >= 1.5) & (time < 3.5)
+    audio[isolated_machine] = (0.10 * np.sin(2 * np.pi * 900 * time[isolated_machine]))[
+        :, None
+    ]
+    audio[adjacent_machine] = (
+        0.10 * np.sin(2 * np.pi * 1100 * time[adjacent_machine])
+    )[:, None]
+    audio[speech] = (0.006 * np.sin(2 * np.pi * 180 * time[speech]))[:, None]
+    source = tmp_path / "mixed-regions.wav"
+    output = tmp_path / "mixed-regions-enhanced.wav"
+    wavfile.write(source, sample_rate, audio)
+
+    correction_calls: list[set[str]] = []
+    apply_corrections = pipeline_module.apply_machine_region_corrections
+
+    def record_corrections(samples, rate, analysis, corrections_db, fade_ms):
+        correction_calls.append(set(corrections_db))
+        return apply_corrections(samples, rate, analysis, corrections_db, fade_ms)
+
+    monkeypatch.setattr(
+        pipeline_module, "apply_machine_region_corrections", record_corrections
+    )
+    report = EnhancementPipeline(PROFILES["product-demo"], detector=FakeVad()).run(
+        source, output=output, dry_run=False
+    )
+
+    source_stage = next(
+        stage for stage in report["stages"] if stage["name"] == "source-balance"
+    )
+    abstained = set(source_stage["abstained_regions"])
+    operated = {operation["region_id"] for operation in source_stage["operations"]}
+
+    assert output.is_file()
+    assert source_stage["status"] == "applied"
+    assert abstained
+    assert operated
+    assert abstained.isdisjoint(operated)
+    assert all(abstained.isdisjoint(call) for call in correction_calls)
+    final_evaluations = {
+        item["region_id"]: item["status"]
+        for item in source_stage["final_region_evaluations"]
+    }
+    assert all(
+        final_evaluations[region_id] == "abstained_overlap" for region_id in abstained
     )


### PR DESCRIPTION
## What changed

- mark padded machine-audio regions that cross a detected speech boundary so `source-balance` uses its explicit-abstention path
- preserve those abstentions through downstream compensation and final verification, including mixed safe/unsafe region sets
- make `resolved_operations_sha256` hash the stable pre-encode operation plan, excluding render-only verification diagnostics
- add regressions for adjacent machine/speech overlap, mixed-region downstream correction, and dry-run/render hash stability
- clarify the hash boundary in the internal auto-enhancement workflow reference

## Why

Headless Claude Sonnet 5 at `xhigh` effort reviewed baseline PR #5 and reproduced two contract defects. Its next pass found a downstream compensation path that could reintroduce an abstained overlap. Both paths are fixed here. A final fresh pass returned `CONVERGED` with no actionable findings after tracing the cumulative stack.

## Validation

- `uv run pytest -q` (26 passed)
- `uvx ruff check src tests`
- `uvx ruff format --check src tests`
- skill validation via `quick_validate.py`
- `git diff --check`
- multiple headless `claude -p --model claude-sonnet-5 --effort xhigh` review passes through convergence

This PR is stacked on #5 and contains only adversarial-review fixes.