### PR TITLE
Fix fifteen defects across the CLI, and the tests that could not have caught them

### DIFF
--- a/.agents/skills/audio-cli/references/enhance-audio.md
+++ b/.agents/skills/audio-cli/references/enhance-audio.md
@@ -104,4 +104,11 @@ a machine-readable remedy. The refusals worth recognizing:
   for the case the person asks for by name.
 - **output would overwrite the input**, or an output path is missing for a real render. Both protect
   the canonical original.
+- **the output or the report already exists.** Nothing is replaced unless the person asked for it,
+  and the message names the flag that does. `inspect` checks its report destination before it
+  decodes anything, so this refusal costs a retry rather than the analysis.
+- **the audio is too short to have a loudness measurement.** Integrated loudness is gated in 400 ms
+  blocks, so a clip shorter than one has none however loud it is. The refusal quotes the true peak
+  that proves the signal is not silent and names the stage to skip. Relay it that way: reporting a
+  short clip as silent is the wrong answer this message exists to prevent.
 - **an invalid adjustment file**, which is its own lane — see [targeted-fixes.md](targeted-fixes.md).

--- a/.agents/skills/audio-cli/references/model-packages.md
+++ b/.agents/skills/audio-cli/references/model-packages.md
@@ -59,8 +59,10 @@ Three things to read off that table rather than guess:
 
 Selecting by stack deliberately over-provisions: it takes every package that stack *can* use,
 diarizer and aligner included. Prefer explicit ids when the request is narrow and the difference is
-gigabytes. Capability-based selection is reserved and does not narrow anything yet, so it cannot be
-used to trim a download today.
+gigabytes. Capability-based selection cannot trim a download today, and `pull` **refuses `--want`**
+with exit 2 rather than accepting a flag it would ignore. Pass a stack or a list of ids, never both:
+that is a conflict, also exit 2, because a stack is a guess about what might be needed and a list of
+ids is an instruction.
 
 ## Expect a pull to be long, and silent
 
@@ -74,11 +76,21 @@ it. Progress goes to stderr; stdout is a JSON receipt whose `pulled_known_bytes`
 *this* pull added, and whose `hub_revisions_pre_existing` names what was already cached and therefore
 not downloaded again.
 
+Re-running a finished `pull` is cheap and safe: anything already provisioned comes back under
+`skipped` and is not touched, so the receipt for a second run lists no packages and no bytes. Read
+`skipped` as "already there", never as "failed". Forcing the work anyway is `--repair PACKAGE`, and
+that is not something to reach for routinely — it re-downloads.
+
 Then confirm with `audio packages verify`. It exits **3** if any check fails and names a `fix` for
 each failure. Two different repairs exist and the failure tells you which: a package whose files
 changed or vanished is re-materialized with `pull --repair PACKAGE`, while a failure naming a runtime
 environment is re-synced with `verify --repair`. Read the `fix` from the payload instead of choosing
 from memory.
+
+Quote what a passing entry actually says. `digest: "ok"` means the bytes were hashed against a pin,
+and only the speech-activity model has one; the others report the `revision` they pinned, which says
+the pin is recorded and the weights are present, not that anything was hashed. Never summarize a
+`revision` entry as "digest verified".
 
 Expect `license_unreviewed` among a pull's warnings. It is non-blocking, and it means nobody has read
 the license the model card declares. Report it, and never describe a declared license as a cleared
@@ -130,9 +142,15 @@ tool, or the provisioning root outlives the only thing that knows how to describ
 | Code | Meaning | What to do |
 | --- | --- | --- |
 | 0 | done | continue |
-| 2 | the request was wrong — an unknown package or stack, a package that was never provisioned | correct the name; the error usually carries an `allowed` list |
+| 2 | the request was wrong — an unknown package or stack, a package that was never provisioned, or an argument the command cannot honour (`--want`; `--stack` beside package ids) | run the `fix` the payload names; for a bad name the error usually carries an `allowed` list |
 | 3 | provisioning is incomplete or broken — a failed integrity check, a missing tool, a failed verify | run the `fix` the payload names, verbatim |
 
 An absent toolchain blocks only the packages that need it — `doctor` says so, those packages report
 `requires_tool`, and everything else still provisions. Report the blocked capability rather than
 substituting something else for it.
+
+That cuts two ways, deliberately. `pull --stack S` on a machine missing a toolchain exits **0**,
+provisions everything it can, and names what it could not in a `warnings` entry carrying
+`blocking: true` — so check `warnings` on a successful pull, not only the exit code. Naming that
+package on the command line instead exits **3**, because skipping something asked for by name would
+be worse than refusing it.

--- a/.agents/skills/audio-cli/references/model-packages.md
+++ b/.agents/skills/audio-cli/references/model-packages.md
@@ -122,6 +122,10 @@ Three readings that trip people up:
 go when their last package does, and the report names what was kept and why. Neither touches media or
 transcript output.
 
+`remove` is all-or-nothing across the names you give it: one that was never provisioned refuses the
+whole command with exit 2 and deletes nothing, so a typo costs a retry rather than gigabytes. Read
+`removed` for what actually went; it never names a package the command left alone.
+
 Because weights sit in that shared cache, teardown draws one line: a revision **this machine's root
 downloaded** is deleted, and a revision that was **already there** when it was pulled is retained,
 since it may belong to another tool or an earlier experiment. That is why a purge can legitimately

--- a/.agents/skills/audio-cli/references/model-packages.md
+++ b/.agents/skills/audio-cli/references/model-packages.md
@@ -31,6 +31,12 @@ it lives. All three are read-only.
 are created and removed with the packages that need them. A `provisional` marker on one is a note
 about a possible future change, not a warning, and it changes nothing about any command.
 
+Read two fields there, not one. The `state` is the registry's own record — `ready` means this root
+provisioned the environment, not that anything in it can run — and `blocked_by_missing_tool` beside
+it is the usability half: a non-empty list names a tool the environment needs that is off `PATH`. An
+environment can honestly be `ready` with a blocked tool, because a stack pull provisions what needs
+no toolchain and reports what it skipped. `verify` is what turns the pair into one verdict.
+
 ## Translate a request into package ids
 
 Someone names a stack — `qwen-1.7b`, `qwen-0.6b`, `vibevoice`, or `firered` — and what they want
@@ -92,6 +98,29 @@ and only the speech-activity model has one; the others report the `revision` the
 the pin is recorded and the weights are present, not that anything was hashed. Never summarize a
 `revision` entry as "digest verified".
 
+`verify` also states one verdict per provisioned environment, and `drifted` is the only one this
+command can repair:
+
+| Verdict | Means | Your move |
+| --- | --- | --- |
+| `ok` | every check that applies to it passed | continue |
+| `drifted` | its installed set no longer matches its lock | `verify --repair`; until then the drift sits in `failed` and the command exits 3 |
+| `blocked` | a tool it requires is off `PATH`, so nothing in it can run whatever the registry holds | report the missing tool; no `audio` command installs one |
+| `absent` | this root has not provisioned it | pull the packages that need it |
+
+`blocked` is the one to slow down on, because it does **not** fail the command: nothing provisioned
+is broken and there is no `fix` to name, so `verify` exits 0 while reporting an environment that can
+execute nothing. Reading the exit code alone there tells someone a capability is available on a
+machine that cannot run it. The pinned private-API guard is the same shape — its
+`mlx_audio_private_api_matches_expected` can come back `false`, or `null` where no verdict was
+reachable, with the command still exiting 0, and a `null` is not a pass.
+
+One package builds rather than downloads, and its build can fail late. A Swift product that compiles
+but will not launch is refused at exit **3** with `package_build_unusable`; the registry entry stays
+`pulling`, so `list` reports it not ready and nothing treats it as available. The `fix` is a
+`pull --repair` on that package. `product_runs: true` in the receipt is the only version of that
+package that counts — do not report a diarizer as provisioned without it.
+
 Expect `license_unreviewed` among a pull's warnings. It is non-blocking, and it means nobody has read
 the license the model card declares. Report it, and never describe a declared license as a cleared
 one.
@@ -147,7 +176,7 @@ tool, or the provisioning root outlives the only thing that knows how to describ
 | --- | --- | --- |
 | 0 | done | continue |
 | 2 | the request was wrong — an unknown package or stack, a package that was never provisioned, or an argument the command cannot honour (`--want`; `--stack` beside package ids) | run the `fix` the payload names; for a bad name the error usually carries an `allowed` list |
-| 3 | provisioning is incomplete or broken — a failed integrity check, a missing tool, a failed verify | run the `fix` the payload names, verbatim |
+| 3 | provisioning is incomplete or broken — a failed integrity check, a missing tool for a package named by id, a build whose product will not run, a drifted environment | run the `fix` the payload names, verbatim |
 
 An absent toolchain blocks only the packages that need it — `doctor` says so, those packages report
 `requires_tool`, and everything else still provisions. Report the blocked capability rather than

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # Working in this repository
 
-A local-first `audio` CLI for agent workflows: measure audio, enhance it deterministically, and
-(in progress) transcribe it. Every command prints JSON on stdout for a caller to dispatch on;
-prose interpretation belongs in your reply, not in the payload.
+A local-first `audio` CLI for agent workflows: measure audio, enhance it deterministically,
+provision the model packages and runtimes transcription will need, and (in progress) transcribe it.
+`inspect`, `enhance`, `doctor`, and `packages` ship; `transcribe` does not exist yet. Every command
+prints JSON on stdout for a caller to dispatch on; prose interpretation belongs in your reply, not
+in the payload.
 
 ## The rule that matters most
 
@@ -18,13 +20,17 @@ Two invariants that follow, and hold everywhere:
 - **The original media is canonical.** Nothing modifies a source file. Renders and transcripts
   refer back to the source timeline.
 - **Absence is meaningful.** A field that a backend did not supply stays absent rather than
-  becoming a null, a zero, or a default that reads like a measurement.
+  becoming a null, a zero, or a default that reads like a measurement. The sharpest instance:
+  `pull` recorded `digest_verified: true` for every Hub package and hashed none of them — the
+  manifest pins a *revision* and carries no `sha256` to hash a snapshot against — so `verify`
+  printed `digest: "ok"` for a check no code performs. The repair is to claim what is true (the
+  pinned `revision`) rather than to confess what is not with a `false`.
 
 ## Where truth lives
 
 | Document | Authoritative for |
 | --- | --- |
-| [VOCABULARY.md](VOCABULARY.md) | Every name in the transcription schema, the floors, and the retired words. Check it before coining a term. |
+| [VOCABULARY.md](VOCABULARY.md) | Every name in the transcription schema, the provisioning states and `verify` verdicts, the floors, and the retired words. Check it before coining a term. |
 | [TRANSCRIBE_CONTRACT.md](TRANSCRIBE_CONTRACT.md) | The `transcribe` command surface, exit codes, and payloads. |
 | [TRANSCRIBE_HAPPY_PATH.md](TRANSCRIBE_HAPPY_PATH.md) | Expected stdout, key for key. The diff target. |
 | [ENVIRONMENTS.md](ENVIRONMENTS.md) | How model packages and their runtimes are provisioned, and why the layout is what it is. |
@@ -33,7 +39,13 @@ Two invariants that follow, and hold everywhere:
 
 Specification documents are enforced, not decorative: `tests/test_spec_docs.py` and
 `tests/test_environments.py` fail when a payload, a name, or an environment drifts from what
-these documents publish.
+these documents publish. Those two compare documents against documents, which cannot catch a
+document the *code* disagrees with, so `tests/test_shipped_commands_match_the_document.py` runs
+the commands that already exist — `doctor`, `packages list`, `packages verify` — and diffs their
+real stdout against TRANSCRIBE_HAPPY_PATH.md, key set and nesting rather than values. All three
+had drifted when it was written. Where the documents disagree with each other it abstains and
+names the dispute instead of ratifying a side; the open one is the shape of `failed[]`, recorded
+in HANDOFF.md. Add a shipped command to it when you ship one.
 
 ## Evidence conventions
 
@@ -53,7 +65,7 @@ Model weights and their runtimes are provisioned **only** by `audio packages pul
 hand-download weights, hand-create a virtual environment, or edit a lock file to make an install
 succeed — the pins are what make the recorded measurements mean anything.
 
-## Two habits learned the hard way
+## Habits learned the hard way
 
 - **Do not add structure nobody dispatches on.** A capability report here shed four nested
   objects that each seemed justified when added. The test is whether a caller branches on it.
@@ -61,6 +73,20 @@ succeed — the pins are what make the recorded measurements mean anything.
   output a stage never emits; it was inert and its test passed vacuously. When you write an
   invariant, write the assertion that would fail if it were violated, then check that it can
   fail.
+- **A flag that parses is not a flag that works.** `--repair` was declared, documented in
+  TRANSCRIBE_CONTRACT.md, and named in four `fix` strings `verify` emits, and no code read it.
+  `--want` was accepted and ignored; `--stack` beside named packages dropped the stack. The cheap
+  sweep that finds the rest: neutralize each `repair`/`force`/`dry_run`/`stack`/`allow_*` branch
+  in turn and run the suite. Six of twenty were invisible. A flag the code cannot honour yet is
+  refused at exit 2, never accepted quietly.
+- **A double must be able to represent the state a repair produces.** `FakeToolchain` could not
+  stop being drifted, so a repair test's final assertion ran against a second, undrifted toolchain
+  that reports `ok` either way and the `if drift and repair` branch never executed. When a double
+  cannot reach the post-repair state, the test passes without the repair running — and two payload
+  shapes here turned out to be unreachable rather than untested for the same reason.
+- **A parameter that decides nothing is worse than a missing one.** `vad_min_silence_ms` declared
+  300 ms while a hard-coded merge downstream required 540, so the profile's number was inert
+  across a 240 ms band. Two thresholds answering one question can only disagree; keep one.
 
 ## Skills
 

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -226,6 +226,32 @@ download discoverable at all — VOCABULARY requires `purge` to find everything 
 registry alone, and a registry that only gains entries on success leaves orphaned bytes that
 nothing can name.
 
+**A `ready` package is skipped rather than re-materialized.** `pull` used to re-do the work
+unconditionally: re-hashing a multi-gigabyte artifact, re-cloning and re-installing a checkout,
+rebuilding the Swift product. Measured, a second `pull` of a ready `silero-vad` moved its
+`pulled_utc` from `00:53:35Z` to `01:10:40Z` — it had done the whole thing again. The cost that
+matters is not the time, though: the `pulling` entry written first means an interrupt during a
+pointless re-pull downgrades a working install, so the crash-safety rule above turns against a
+package nothing was wrong with. Skipped packages are reported in the receipt's `skipped` array
+and contribute nothing to `pulled_known_bytes`.
+
+**`pull --repair` forces re-materialization, and had to be wired to do it.** The flag was
+declared, documented, and named in four `fix` strings, and nothing read it. For a Hub package
+that mattered most: `snapshot_download` returns a revision the cache already holds as it
+stands, so a repair of a corrupt snapshot reported success having moved no bytes. `--repair`
+now passes `force_download=True`, and deletes a checkout before re-cloning rather than patching
+a tree whose state is what is in doubt. It is a no-op for `silero-vad` by construction and for
+that one reason only: `url_file` re-hashes the file against the manifest pin and re-downloads
+unless it matches, so a match already is the strongest re-materialization available.
+
+**A stack tolerates a toolchain-blocked package; a named one does not.** `--stack` selects every
+package a stack can use, which is a superset guess, so a machine with no Swift toolchain
+provisions the rest of the stack and reports `fluidaudio` as a blocking `warnings` entry. Exit 3
+is reserved for a stack where nothing at all was provisionable, and for a package named on the
+command line — an instruction, where a silent skip would be worse than a refusal. Raising on the
+first blocked package is what this replaced, and because `select` sorts by id, `fluidaudio`
+sorted first and `pull --stack qwen-1.7b` on a toolchain-less machine provisioned nothing at all.
+
 **Reference counts are derived, never stored.** `remove <package>` deletes that package's
 artifacts, then removes its environment only if no other non-absent package targets it. A
 stored count is a second copy of a fact the table already holds, and it would eventually
@@ -247,7 +273,14 @@ of virtual environment. Revisions the cache no longer holds are reported as
 
 Four checks, all cheap, none loading weights:
 
-1. **Artifact digests** for every `weights` package, against what `pull` recorded.
+1. **Artifact digests** for every package pinned by content hash, which is `silero-vad` and
+   nothing else. The manifest pins the Hub packages by *revision* and carries no `sha256` for
+   them, so there is nothing to hash a snapshot against: those report the revision they
+   materialized, and the check that applies to them is that the snapshot still exists. `verify`
+   says `digest: "ok"` only where bytes were hashed and `revision`/`revisions` where a revision
+   is pinned — the two are different claims and must not print the same word. Every Hub package
+   recorded `digest_verified: true` at pull time until this was corrected, which made `verify`
+   report a digest check for eight packages and perform it for one.
 2. **Environment equality with its lock** — `uv pip freeze` against the locked set. A drifted
    environment is a repairable state, not a fatal one; `--repair` re-syncs.
 3. **The `mlx-audio` private-API guard** — the source hash over

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -294,6 +294,17 @@ Four checks, all cheap, none loading weights:
 Each check has a failure that must be reachable, not merely described: reverting the patch,
 deleting a wheel, or bumping `mlx-audio` each has to make exactly one of these fail.
 
+Per-environment, `verify` states a verdict rather than the registry's state: `ok`, `drifted`,
+`blocked`, or `absent`. `blocked` means a tool in that environment's `requires_tool` is not on
+`PATH`, so nothing in it can run — this tool launches the Swift product through `swift run` —
+and it is reachable exactly because a stack pull now provisions around a blocked package:
+`speaker-diarization-coreml` needs no toolchain, so it lands in `swift` and leaves the
+environment `ready` in the registry while holding nothing executable. That state used to be
+unreachable, since the stack pull aborted and the environment stayed absent. It is not a
+`failed` entry, so `verify` still exits 0: nothing provisioned is broken, and no `audio` command
+installs a toolchain for a `fix` to name. `doctor`, `list`, and `path` keep publishing the
+registry's own `state`, which is a different fact — see VOCABULARY.md for both enumerations.
+
 ## Running a stage in another environment
 
 The recorded evidence used **strictly sequential fresh subprocesses** — that is what

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -259,6 +259,18 @@ disagree with it.
 
 **`purge` reads the registry, reports reclaimable bytes, and touches no media or output.**
 
+**A teardown validates before it deletes.** `remove` resolves every name it was given against
+the registry and refuses the whole command if one of them is not there, because it used to delete
+as it went: `remove vibevoice-asr-7b firered-asr2` discarded 17 GiB, then raised on the typo, and
+the single `save_registry` after the loop never ran — so the registry rolled back and went on
+calling a package with no bytes `ready`. `missing_packages` keys on `state`, so nothing noticed
+until a model load. It is the mirror image of the `pulling` rule above: a pull that dies is honest
+about being incomplete, and that teardown was not. Each entry is now dropped and saved as its own
+files go, rather than in one write at the end, which also closes the narrower version of the same
+window in `purge` — a Hub cache that fails mid-teardown used to leave every package `ready` with
+nothing behind it. `purge` never had the validation defect, because it takes its list from the
+registry rather than from a caller. A repeated name removes once and is reported once.
+
 **A teardown reports what it actually freed.** Two things follow, and the first was got wrong
 before it was got right. Most of the bytes are not under the root at all — they are Hub
 revisions — so `remove` and `purge` delete exactly the revisions the registry records, by

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,17 +11,32 @@ stack and states requirements, plus its associated agent skill.
   Their contract and usage are in [README.md](README.md); do not regress the
   deterministic, render-from-original enhancement flow.
 - `audio packages` and `audio doctor` are implemented, over the four provisioned
-  environments in [ENVIRONMENTS.md](ENVIRONMENTS.md). Their tests run entirely on a
-  `FakeToolchain` and `FakeFetcher`, so the real Hub, `uv venv`, digest, and Swift-build
-  paths are unexercised, and nothing is provisioned on any machine yet.
-- An audit of that layer found eight defects and all eight are fixed on
-  `fix/cli-provisioning-bugs`. The two worth remembering as *kinds* of mistake, because both
-  survived review by looking finished: `pull` recorded `digest_verified: true` for every Hub
-  package and hashed none of them, so `verify` reported a check it never ran; and `--repair`
-  was declared, documented, and named in four `fix` strings while being read by no code at
-  all. A flag that parses is not a flag that works, and a payload key is a claim about work
-  someone has to have done. `pull` is now idempotent, tolerates a toolchain-blocked package
-  when a *stack* selected it, and refuses `--want` rather than ignoring it.
+  environments in [ENVIRONMENTS.md](ENVIRONMENTS.md). The suite runs on a `FakeToolchain` and
+  `FakeFetcher`, but the real paths are no longer unexercised: all four environments have been
+  built from their hash-pinned locks and `verify` reports each `ok` against its own, a forced
+  repair moved 1,101,647,163 measured bytes over the network for a 1,010,773,761-byte package,
+  the Swift product builds and launches, and the `mlx-audio` private-API guard matches its pin
+  with `signature_ok: true`. `torch-firered` resolves to transformers 5.1.0 and
+  `torch-vibevoice` to 4.57.6, so the partition is installed rather than inferred.
+- An audit of the CLI found **fifteen** defects and all fifteen are fixed on
+  `fix/cli-provisioning-bugs` — ten in provisioning, five in the enhancement engine and its
+  documents. The kinds of mistake worth remembering, because each survived review by looking
+  finished:
+  - **A claim nobody earned.** `pull` recorded `digest_verified: true` for every Hub package and
+    hashed none of them; the manifest carries no `sha256` for a Hub source, so there was nothing
+    to hash against. `verify` reported a check it never ran, and its honest `unverified` branch
+    was unreachable.
+  - **A flag that parses is not a flag that works.** `--repair` was declared, documented, and
+    named in four `fix` strings while being read by no code at all. A mutation scan then
+    neutralized all 20 flag branches and found six more the suite could not see.
+  - **A parameter that decided nothing.** `vad_min_silence_ms` declared 300 ms while a second
+    hard-coded merge required 540; two thresholds answering one question can only disagree.
+  - **A bound the media does not have.** A resampler rounding up let a speech region end after
+    the end of the file, which then made a treatment extension negative.
+  - **A recorded failure that changed no outcome.** A Swift build whose product could not launch
+    reported `product_runs: false` and exited 0 with an empty `warnings`.
+  `pull` is now idempotent, tolerates a toolchain-blocked package when a *stack* selected it,
+  refuses `--want` rather than ignoring it, and refuses a build whose product will not run.
 - Two things that sweep surfaced and did **not** settle, both about `verify`. A moved
   `mlx-audio` private API is reported and never reaches `failed`, so `verify` exits 0 while
   saying `mlx_audio_private_api_matches_expected: false` — the guard the recorded Qwen timings

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # Agent handoff
 
-Updated 2026-08-16. This repository currently has a production-oriented audio
+Updated 2026-08-18. This repository currently has a production-oriented audio
 enhancement CLI and a completed ASR research/distillation phase. The next phase
 is to turn the ASR decisions into a transcription CLI where the caller picks a
 stack and states requirements, plus its associated agent skill.
@@ -10,9 +10,14 @@ stack and states requirements, plus its associated agent skill.
 - `audio inspect` and `audio enhance` are implemented under `src/audio_cli/`.
   Their contract and usage are in [README.md](README.md); do not regress the
   deterministic, render-from-original enhancement flow.
+- `audio packages` and `audio doctor` are implemented, over the four provisioned
+  environments in [ENVIRONMENTS.md](ENVIRONMENTS.md). Their tests run entirely on a
+  `FakeToolchain` and `FakeFetcher`, so the real Hub, `uv venv`, digest, and Swift-build
+  paths are unexercised, and nothing is provisioned on any machine yet.
 - ASR research for [Issue #2](https://github.com/fyang0507/audio-processing-cli/issues/2)
-  is on branch `codex/asr-benchmark-field-guide` in
-  [draft PR #8](https://github.com/fyang0507/audio-processing-cli/pull/8).
+  landed on `main` in [#8](https://github.com/fyang0507/audio-processing-cli/pull/8), and the
+  `transcribe` specification plus the provisioning layer landed in
+  [#15](https://github.com/fyang0507/audio-processing-cli/pull/15).
 - The benchmark harness, manifests, compact results, and controlled research
   record live under `model_tests/`. Raw media, downloaded model weights, and
   local run directories are intentionally ignored.
@@ -254,7 +259,7 @@ and experiment digest rather than the full findings file.
 ## Working commands
 
 ```bash
-git switch codex/asr-benchmark-field-guide
+git switch main
 uv sync --extra dev
 uv run --extra dev pytest
 ```

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -22,6 +22,19 @@ stack and states requirements, plus its associated agent skill.
   all. A flag that parses is not a flag that works, and a payload key is a claim about work
   someone has to have done. `pull` is now idempotent, tolerates a toolchain-blocked package
   when a *stack* selected it, and refuses `--want` rather than ignoring it.
+- Two things that sweep surfaced and did **not** settle, both about `verify`. A moved
+  `mlx-audio` private API is reported and never reaches `failed`, so `verify` exits 0 while
+  saying `mlx_audio_private_api_matches_expected: false` — the guard the recorded Qwen timings
+  depend on cannot fail the command. And a `blocked` environment is likewise exit 0, which is
+  deliberate and documented. Whether the first should join the second or become an exit-3 check
+  is a contract decision; there is no `audio` command that would fix it, so its `fix` would be a
+  sentence.
+- The suite's doubles are now held to one rule, learned twice: **a double must be able to
+  represent the state a repair produces.** `FakeToolchain` could not stop being drifted and
+  `FakeFetcher` would rewrite a snapshot unasked, and each made a repair test pass without the
+  repair running. A flag-mutation scan over every `repair`/`force`/`dry_run`/`allow_*` branch in
+  the command surfaces is the cheap way to find the rest; it found six unasserted branches on
+  first run, all now covered.
 - ASR research for [Issue #2](https://github.com/fyang0507/audio-processing-cli/issues/2)
   landed on `main` in [#8](https://github.com/fyang0507/audio-processing-cli/pull/8), and the
   `transcribe` specification plus the provisioning layer landed in

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -14,6 +14,14 @@ stack and states requirements, plus its associated agent skill.
   environments in [ENVIRONMENTS.md](ENVIRONMENTS.md). Their tests run entirely on a
   `FakeToolchain` and `FakeFetcher`, so the real Hub, `uv venv`, digest, and Swift-build
   paths are unexercised, and nothing is provisioned on any machine yet.
+- An audit of that layer found eight defects and all eight are fixed on
+  `fix/cli-provisioning-bugs`. The two worth remembering as *kinds* of mistake, because both
+  survived review by looking finished: `pull` recorded `digest_verified: true` for every Hub
+  package and hashed none of them, so `verify` reported a check it never ran; and `--repair`
+  was declared, documented, and named in four `fix` strings while being read by no code at
+  all. A flag that parses is not a flag that works, and a payload key is a claim about work
+  someone has to have done. `pull` is now idempotent, tolerates a toolchain-blocked package
+  when a *stack* selected it, and refuses `--want` rather than ignoring it.
 - ASR research for [Issue #2](https://github.com/fyang0507/audio-processing-cli/issues/2)
   landed on `main` in [#8](https://github.com/fyang0507/audio-processing-cli/pull/8), and the
   `transcribe` specification plus the provisioning layer landed in

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ original + profile
 
 The CLI reports what it measured, which versioned rule matched, the exact DSP parameters it resolved, and whether the result conforms to the selected profile. It does not label audio universally “good” or “bad,” and it abstains where a mixed track cannot be changed safely.
 
+The second implemented surface is provisioning: `audio doctor` reports what the machine supplies, and `audio packages` installs, verifies, and reclaims the pinned model packages and runtimes that transcription will need. It is described under [Model packages](#model-packages). There is no `transcribe` command yet — provisioning shipped ahead of it deliberately, so nothing downloads a model behind a caller's back.
+
 This implements [Issue #4 — Profile-driven automatic audio enhancement](https://github.com/fyang0507/audio-processing-cli/issues/4) within the product boundary established by [Issue #1](https://github.com/fyang0507/audio-processing-cli/issues/1).
 
 ## Install
@@ -48,7 +50,7 @@ uv sync --extra dev
 uv run audio enhance --list-stages --profile product-demo
 ```
 
-The first inspection downloads the pinned 2.2 MB Silero VAD 6.2.1 ONNX model from its official repository and verifies its SHA-256 digest. Set `AUDIO_PROCESSING_VAD_MODEL` or pass `--vad-model` to use a pre-populated local model. No PyTorch runtime is required.
+The first inspection downloads the pinned 2.2 MB Silero VAD 6.2.1 ONNX model from its official repository and verifies its SHA-256 digest. It is the only model this CLI fetches without being asked, the only one pinned by content hash rather than by revision, and `audio packages pull silero-vad` provisions it explicitly instead. Set `AUDIO_PROCESSING_VAD_MODEL` or pass `--vad-model` to use a pre-populated local model. No PyTorch runtime is required.
 
 ## Use
 
@@ -99,6 +101,8 @@ audio enhance demo.mp4 \
 
 If `program-loudness` is skipped, true-peak validation still runs and the command fails instead of silently limiting a clipping signal.
 
+Integrated loudness is gated in 400 ms blocks by EBU R128, so an input shorter than one block has none to normalize however loud it is. The refusal says so, quotes the true peak that proves the signal is not silent, and names the flag that skips the stage; a short clip is never reported as silence.
+
 ## Profiles and stages
 
 Every stage ends as `applied`, `no_op`, `skipped`, `abstained`, or `failed`. The fixed processing order is:
@@ -109,7 +113,7 @@ Every stage ends as `applied`, `no_op`, `skipped`, `abstained`, or `failed`. The
 4. `source-balance` — balances non-overlapping machine-audio regions against treated speech for `product-demo`; it is disabled for `transcription`.
 5. `program-loudness` — uses EBU R128 measurement to resolve fixed gain, then iterates an oversampled true-peak limiter without undoing earlier region balance.
 
-`transcription@4` targets −23 LUFS / −3 dBTP. `product-demo@4` targets −16 LUFS / −1.5 dBTP and keeps detected machine audio between 4 and 2 dB below the treated speech reference. Version 3 grows reliable VAD seeds to neighboring acoustic activity, reserves silent guard time, and places speech-treatment fades outside that guard. Version 4 changes no threshold: it makes `vad_min_silence_ms` the only thing that decides where a speech region breaks, where a second hard-coded merge had previously required 540 ms of silence to split a region the profile said should split at 300. Renders therefore differ from version 3 wherever a pause falls between those figures — the local 27.8 s fixture moves from 6 speech regions to 10. Every threshold and bound is emitted in the report’s `profile` object.
+`transcription@4` targets −23 LUFS / −3 dBTP. `product-demo@4` targets −16 LUFS / −1.5 dBTP and keeps detected machine audio between 4 and 2 dB below the treated speech reference. Version 3 grows reliable VAD seeds to neighboring acoustic activity, reserves silent guard time, and places speech-treatment fades outside that guard. Version 4 changes no threshold: it makes `vad_min_silence_ms` the only thing that decides where a speech region breaks, where a second hard-coded merge had previously required 540 ms of silence to split a region the profile said should split at 300. Renders therefore differ from version 3 wherever a pause falls between those figures — the local 27.8 s fixture moves from 6 speech regions to 10. Detected regions are also clamped to the source timeline: the 16 kHz resample used for detection rounds its sample count up, which had let a region reach 27.753375 s in a 27.753333 s file and then made a speech treatment end 0.042 ms *before* the last detected sample. Every threshold and bound is emitted in the report’s `profile` object.
 
 ## Constrained adjustments
 
@@ -161,6 +165,27 @@ A successful render verifies:
 - the source hash, profile version, resolved operations, output hash, and runtime versions are recorded.
 
 The report demonstrates deterministic profile conformance. Perceptual preference still requires human listening evidence; overlapping sources still require separate tracks or a future separation capability.
+
+## Model packages
+
+`audio packages pull` is the only thing that fetches a model or prepares a runtime for it. A missing package is a refusal carrying a `fix`, never a background download. [ENVIRONMENTS.md](ENVIRONMENTS.md) is authoritative for the four runtime environments, the pins, and why the layout is what it is.
+
+```bash
+audio doctor                            # tools, toolchains, memory, disk, and provisioning state
+audio packages list                     # what is provisioned, and what it occupies
+audio packages pull --stack qwen-1.7b   # provision every package that stack can use
+audio packages verify                   # re-check what is provisioned; exit 3 if a check fails
+audio packages purge --dry-run          # what a teardown would reclaim, reclaiming nothing
+```
+
+Six behaviours to know before dispatching on the payloads:
+
+- `pull` accepts package ids **or** `--stack`, never both, and it refuses `--want` at exit 2 rather than accepting a capability filter it cannot honour until the planner lands.
+- A package the registry already calls `ready` is reported under `skipped` and not re-materialized; it contributes nothing to `pulled_known_bytes`. `pull --repair PACKAGE` forces the work anyway, re-downloading a Hub snapshot and re-cloning a checkout rather than trusting what is on disk.
+- `--stack` tolerates a package its toolchain blocks: the rest of the stack provisions, the exit stays 0, and the blocked package appears in `warnings` with `blocking: true`. Naming that package on the command line is an instruction rather than a guess, so there an absent toolchain is exit 3.
+- `verify` publishes one verdict per environment — `ok`, `drifted`, `blocked`, or `absent`. Only `drifted` is repairable here, with `verify --repair`. `blocked` means a tool the environment requires is off `PATH`, so nothing in it can run; it exits 0 and says so rather than naming a fix this CLI cannot perform.
+- `digest: "ok"` is published only for a package pinned by content hash, which is `silero-vad` and nothing else. Hub packages publish the `revision` they pinned — a different claim, deliberately a different key.
+- `remove` resolves every name against the registry before deleting anything, and both teardowns drop a registry entry as that package's own bytes go. Weights live in a Hub cache shared with other tools, so a revision this root downloaded is deleted and one that pre-existed is retained; `purge --dry-run` reports the split before a caller promises a total.
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Every stage ends as `applied`, `no_op`, `skipped`, `abstained`, or `failed`. The
 4. `source-balance` — balances non-overlapping machine-audio regions against treated speech for `product-demo`; it is disabled for `transcription`.
 5. `program-loudness` — uses EBU R128 measurement to resolve fixed gain, then iterates an oversampled true-peak limiter without undoing earlier region balance.
 
-`transcription@3` targets −23 LUFS / −3 dBTP. `product-demo@3` targets −16 LUFS / −1.5 dBTP and keeps detected machine audio between 4 and 2 dB below the treated speech reference. Version 3 grows reliable VAD seeds to neighboring acoustic activity, reserves silent guard time, and places speech-treatment fades outside that guard. Every threshold and bound is emitted in the report’s `profile` object.
+`transcription@4` targets −23 LUFS / −3 dBTP. `product-demo@4` targets −16 LUFS / −1.5 dBTP and keeps detected machine audio between 4 and 2 dB below the treated speech reference. Version 3 grows reliable VAD seeds to neighboring acoustic activity, reserves silent guard time, and places speech-treatment fades outside that guard. Version 4 changes no threshold: it makes `vad_min_silence_ms` the only thing that decides where a speech region breaks, where a second hard-coded merge had previously required 540 ms of silence to split a region the profile said should split at 300. Renders therefore differ from version 3 wherever a pause falls between those figures — the local 27.8 s fixture moves from 6 speech regions to 10. Every threshold and bound is emitted in the report’s `profile` object.
 
 ## Constrained adjustments
 

--- a/TRANSCRIBE_CONTRACT.md
+++ b/TRANSCRIBE_CONTRACT.md
@@ -483,14 +483,14 @@ Exit 3. Nothing computed, nothing downloaded, stderr:
   ],
   "total_known_download_bytes": 2463307541,
   "unsized_packages": ["fluidaudio", "speaker-diarization-coreml"],
-  "fix": "audio packages pull --stack qwen-1.7b --want diarization"
+  "fix": "audio packages pull --stack qwen-1.7b"
 }
 ```
 
 ### 1.3 Provision, verify, execute
 
 ```bash
-audio packages pull --stack qwen-1.7b --want diarization
+audio packages pull --stack qwen-1.7b
 audio packages verify
 audio packages list
 audio transcribe run --input meeting.m4a --stack qwen-1.7b --want diarization \
@@ -522,8 +522,7 @@ carries. [ENVIRONMENTS.md](ENVIRONMENTS.md) holds the layout.
 ```bash
 audio transcribe plan --input meeting.m4a --stack qwen-1.7b \
   --want diarization,word_timestamps,overlapped_speech,vad
-audio packages pull --stack qwen-1.7b \
-  --want diarization,word_timestamps,overlapped_speech,vad
+audio packages pull --stack qwen-1.7b
 audio transcribe run --input meeting.m4a --stack qwen-1.7b \
   --want diarization,word_timestamps,overlapped_speech,vad \
   --format json -o meeting.timed.json
@@ -587,7 +586,7 @@ single implementation with a pin reserved for later ones.
 without it this exits 3:
 
 ```bash
-audio packages pull --stack qwen-0.6b --want diarization
+audio packages pull --stack qwen-0.6b
 audio transcribe run --input meeting.m4a --stack qwen-0.6b --want diarization \
   --language Cantonese --format md
 ```
@@ -672,8 +671,7 @@ fields that differ from §1.1** — the envelope, `packages`, and
 ```
 
 ```bash
-audio packages pull --stack vibevoice \
-  --want verbatim,diarization,segment_timestamps,word_timestamps
+audio packages pull --stack vibevoice
 audio packages verify
 audio transcribe run --input demo.mp4 --stack vibevoice \
   --want verbatim,diarization,segment_timestamps,word_timestamps \
@@ -770,17 +768,18 @@ have had to either overclaim that or discard a real result; a downstream `word_i
 scheme has to know which.
 
 ```bash
-audio packages pull --stack firered \
-  --want verbatim,word_timestamps,vad,segment_timestamps
+audio packages pull --stack firered
 audio packages verify
 audio transcribe run --input field.wav --stack firered \
   --want verbatim,word_timestamps,vad,segment_timestamps \
   --format json -o field.transcript.json
 ```
 
-The LID weights are fetched only when `lid` is in the plan, so this
-request provisions less than the full package. Neither figure is recorded in a
-tracked artifact — the only tracked source is a pre-harness "~9.2 GB" note that
+`firered-asr2s` is one package pinning four repositories and `pull` materializes all of
+them, LID weights included, whatever the plan asked for: narrowing a pull to the roles a
+plan actually uses is what `--want` is reserved for, and `pull` refuses that flag today
+rather than appearing to honour it. Neither the whole-package figure nor a narrowed one is
+recorded in a tracked artifact — the only tracked source is a pre-harness "~9.2 GB" note that
 its own document marks as history rather than decision evidence — so both appear
 as `approximate, unrecorded` until per-artifact sizes are recorded the way the
 MLX runs record `weight_bytes`.
@@ -820,7 +819,7 @@ variation that was never measured.
 ```bash
 audio transcribe plan --input field.wav --stack firered \
   --want verbatim,word_timestamps,lid
-audio packages pull --stack firered --want verbatim,word_timestamps,lid
+audio packages pull --stack firered
 audio transcribe run --input field.wav --stack firered \
   --want verbatim,word_timestamps,lid --format json -o field.lid.json
 ```
@@ -858,8 +857,7 @@ is on Qwen. Note the `pull` — entering at this section without it exits 3, sin
 nothing earlier in §3 provisioned a diarizer:
 
 ```bash
-audio packages pull --stack firered \
-  --want verbatim,word_timestamps,diarization,overlapped_speech
+audio packages pull --stack firered
 audio transcribe run --input interview.wav --stack firered \
   --want verbatim,word_timestamps,diarization,overlapped_speech \
   --format json -o interview.firered.json

--- a/TRANSCRIBE_CONTRACT.md
+++ b/TRANSCRIBE_CONTRACT.md
@@ -62,6 +62,7 @@ field not listed for its code, or missing one that is, is a defect:
 | `timing_required_for_format` | 2 | `field`, `provided`, `requires_capability`, `found`, `note` |
 | `packages_not_provisioned` | 3 | `missing`, `total_known_download_bytes`, `unsized_packages` |
 | `package_integrity_failed` | 3 | `failed` (package, check, expected, actual) |
+| `package_build_unusable` | 3 | `package`, `product`, `built`, `fix` |
 | `backend_failed` | 1 | `role`, `backend`, `detail` |
 | `run_incomplete` | 4 | `role`, `backend`, `detail`, `coverage`, `output` |
 
@@ -1028,6 +1029,27 @@ invocation; it checks presence and the registry, so this surfaces either from an
 corruption subtle enough to pass the cheap check fails at model load instead, which is
 `backend_failed` at exit 1 with `fix` pointing at `audio packages verify` — the same
 condition, found later, reported as what it looked like from where it was found.
+
+A built package has a fourth failure of its own: the build succeeded and the executable it
+produced does not launch.
+
+```json
+{
+  "code": "package_build_unusable",
+  "package": "fluidaudio",
+  "product": "fluidaudiocli",
+  "built": true,
+  "fix": "audio packages pull --repair fluidaudio"
+}
+```
+
+Exit 3, and the registry entry stays `pulling`, so `list` and `run` both report the package
+absent rather than ready. `built: true` is kept because it is the useful half of the diagnosis —
+a compile failure and a product that will not start need different responses, and this is the
+second. The condition was real: the product name was hard-coded as `fluidaudio` while
+`Package.swift` at the pinned commit declares `fluidaudiocli`, so `swift run` refused a perfectly
+good build. It is pinned in the manifest beside the commit now, and `pull` refuses instead of
+recording `product_runs: false` and exiting 0.
 
 ### 5.1 Incomplete runs
 

--- a/TRANSCRIBE_DESIGN_HANDOFF.md
+++ b/TRANSCRIBE_DESIGN_HANDOFF.md
@@ -85,11 +85,17 @@ you recognise a settled question when you meet one.
    [#11](https://github.com/fyang0507/audio-processing-cli/issues/11): four provisioned
    environments derived by resolver rather than asserted, hash-pinned locks that ship in the
    wheel, and the registry schema with its crash-safety rule. `audio packages`
-   (`list`/`path`/`pull`/`verify`/`remove`/`purge`) and `audio doctor` are implemented too, but
-   only against fakes: every test in `tests/test_packages.py` runs on a `FakeToolchain` and a
-   `FakeFetcher` in an isolated root, so no real Hub download, `uv venv` creation, digest check,
-   or Swift build has been exercised. `pull --want` is accepted and inert until the planner
-   lands, so `--stack` over-provisions ([#12](https://github.com/fyang0507/audio-processing-cli/issues/12)).
+   (`list`/`path`/`pull`/`verify`/`remove`/`purge`) and `audio doctor` are implemented, and the
+   real paths behind them are exercised: all four environments built from their locks and
+   verified `ok` against each, a forced repair with 1,101,647,163 measured bytes over the wire,
+   the Swift product built and launched, and the `mlx-audio` private-API guard matching its pin.
+   The suite still runs on a `FakeToolchain` and `FakeFetcher` in an isolated root, so treat a
+   green suite as covering the rules and not the integration — the integration evidence is in
+   `fix/cli-provisioning-bugs`. `pull --want` is now **refused** rather than accepted and
+   ignored, until the planner lands
+   ([#12](https://github.com/fyang0507/audio-processing-cli/issues/12)); `--stack` still
+   over-provisions, and now tolerates a package whose toolchain is missing instead of aborting
+   the whole pull.
 4. **Partial results and resume.** Exit 4 writes a result with a coverage ledger. How work
    units are tracked, and where the watermark comes from when completion is non-contiguous,
    is design. The recorded runner processes turns in duration-bucketed order, so completion is

--- a/TRANSCRIBE_DESIGN_HANDOFF.md
+++ b/TRANSCRIBE_DESIGN_HANDOFF.md
@@ -84,8 +84,12 @@ you recognise a settled question when you meet one.
 3. ~~**The environment layout, concretely.**~~ **Done** in issue
    [#11](https://github.com/fyang0507/audio-processing-cli/issues/11): four provisioned
    environments derived by resolver rather than asserted, hash-pinned locks that ship in the
-   wheel, and the registry schema with its crash-safety rule. `audio packages` itself is not
-   implemented.
+   wheel, and the registry schema with its crash-safety rule. `audio packages`
+   (`list`/`path`/`pull`/`verify`/`remove`/`purge`) and `audio doctor` are implemented too, but
+   only against fakes: every test in `tests/test_packages.py` runs on a `FakeToolchain` and a
+   `FakeFetcher` in an isolated root, so no real Hub download, `uv venv` creation, digest check,
+   or Swift build has been exercised. `pull --want` is accepted and inert until the planner
+   lands, so `--stack` over-provisions ([#12](https://github.com/fyang0507/audio-processing-cli/issues/12)).
 4. **Partial results and resume.** Exit 4 writes a result with a coverage ledger. How work
    units are tracked, and where the watermark comes from when completion is non-contiguous,
    is design. The recorded runner processes turns in duration-bucketed order, so completion is

--- a/TRANSCRIBE_HAPPY_PATH.md
+++ b/TRANSCRIBE_HAPPY_PATH.md
@@ -87,22 +87,58 @@ audio doctor
 
 ```json
 {
-  "tool": {"name": "audio-processing-cli", "version": "0.4.0",
+  "tool": {"version": "0.1.0", "python": "3.12.12",
            "path": "/Users/you/.local/bin/audio"},
-  "platform": {"os": "macOS 26.5.2", "arch": "arm64", "hw_model": "Mac16,5"},
-  "external_tools": {"ffmpeg": "8.0", "ffprobe": "8.0", "uv": "0.9.7", "swift": "6.2"},
-  "memory": {"physical_bytes": 68719476736, "available_bytes": 41234567168},
-  "disk": {"root": "/Users/you/Library/Caches/audio-processing-cli",
-           "available_bytes": 402653184000},
-  "environments": {"core": "ready", "mlx": "absent", "torch-firered": "absent",
-                   "torch-vibevoice": "absent", "swift": "absent"},
-  "packages": {"provisioned": [], "count": 0},
-  "warnings": []
+  "platform": {"system": "Darwin", "release": "25.5.0", "machine": "arm64"},
+  "tools": {
+    "ffmpeg": {"path": "/opt/homebrew/bin/ffmpeg", "present": true},
+    "ffprobe": {"path": "/opt/homebrew/bin/ffprobe", "present": true},
+    "git": {"path": "/opt/homebrew/bin/git", "present": true},
+    "huggingface_hub": {"path": null, "present": true},
+    "swift": {"path": "/usr/bin/swift", "present": true},
+    "uv": {"path": "/Users/you/.local/bin/uv", "present": true}
+  },
+  "memory": {"total_bytes": 68719476736, "available_bytes": 30585126912,
+             "note": "Host-wide counters; not process-attributable and not summable with per-stage peaks."},
+  "disk": {"total_bytes": 994662584320, "free_bytes": 107730939904},
+  "root": "/Users/you/Library/Caches/audio-processing-cli",
+  "root_exists": true,
+  "registry": "/Users/you/Library/Caches/audio-processing-cli/registry.json",
+  "environments": {
+    "mlx": {"state": "absent", "python": "3.13.9", "requires_tool": [],
+            "provisional": false, "blocked_by_missing_tool": []},
+    "swift": {"state": "absent", "python": null, "requires_tool": ["swift"],
+              "provisional": false, "blocked_by_missing_tool": []},
+    "torch-firered": {"state": "absent", "python": "3.12.12", "requires_tool": [],
+                      "provisional": false, "blocked_by_missing_tool": []},
+    "torch-vibevoice": {"state": "absent", "python": "3.12.12", "requires_tool": [],
+                        "provisional": true, "blocked_by_missing_tool": []}
+  },
+  "packages": {
+    "firered-asr2s": "absent", "fluidaudio": "absent",
+    "qwen3-asr-0.6b-8bit": "absent", "qwen3-asr-1.7b-8bit": "absent",
+    "qwen3-forcedaligner": "absent", "silero-vad": "absent",
+    "speaker-diarization-coreml": "absent", "vibevoice-asr-7b": "absent"
+  },
+  "note": "An absent swift blocks only the packages that need it; it is reported rather than fatal."
 }
 ```
 
-Exit 0. `swift` present here; absent it would be reported and non-fatal, blocking only
-the packages that need it.
+Exit 0, and unlike every other block in this document this one is **real output**, not a mock —
+`doctor` is implemented, so its shape is checked against a live run by
+`tests/test_shipped_commands_match_the_document.py` rather than maintained by eye — as are the
+`packages list` block in §5 and the `packages verify` block in §1.3, the other two commands that
+ship. Values remain illustrative: paths, versions, and the memory and disk counters are this
+machine's.
+
+`swift` is present here. Absent, it would report `present: false` and appear in the
+`blocked_by_missing_tool` list of the `swift` environment — reported rather than fatal, blocking
+only the packages that need it. That per-environment list is why there is no top-level
+`warnings` array: a blocked environment says so where a caller is already looking.
+
+`environments` reports the four *provisioned* environments and not `core`, which is the CLI's own
+and always present. `packages` is a state per package rather than a count, because a caller
+deciding whether to `pull` needs to know *which* are absent, not how many.
 
 ## 1. Fast long-form transcription — interview
 
@@ -321,14 +357,20 @@ audio packages verify
     {"package": "speaker-diarization-coreml", "digest": "ok"},
     {"package": "qwen3-forcedaligner", "digest": "ok"}
   ],
-  "environments": {"mlx": "ok", "swift": "ok"},
+  "environments": {"mlx": "ok", "swift": "ok", "torch-firered": "absent",
+                   "torch-vibevoice": "absent"},
+  "mlx_audio_private_api_expected_source_hash": "c082690575eedcd28fb76207d032cefd7eac2f9ce5d36df5a7a06575bc45d250",
   "mlx_audio_private_api_source_hash": "c082690575eedcd28fb76207d032cefd7eac2f9ce5d36df5a7a06575bc45d250",
   "mlx_audio_private_api_matches_expected": true,
   "failed": []
 }
 ```
 
-Exit 0.
+Exit 0. `verify` reports every provisioned environment, not only the ones this pull touched, so the
+two `torch` environments appear as `absent` rather than being omitted — an environment missing from
+the map would be indistinguishable from one nobody has looked at. The private-API hash is published
+alongside the value it is compared against, because `matches_expected: true` on its own is a claim
+a reader cannot check.
 
 ### 1.4 Run
 
@@ -1038,22 +1080,22 @@ audio packages list
   "root": "/Users/you/Library/Caches/audio-processing-cli",
   "packages": [
     {"package": "qwen3-asr-1.7b-8bit", "environment": "mlx", "bytes": 2467859030,
-     "license_declared": "apache-2.0", "license_reviewed": false,
+     "state": "ready", "license_declared": "apache-2.0", "license_reviewed": false,
      "used_by_stacks": ["qwen-1.7b"]},
     {"package": "fluidaudio", "environment": "swift", "bytes": null,
-     "license_declared": "apache-2.0", "license_reviewed": true,
+     "state": "ready", "license_declared": "apache-2.0", "license_reviewed": true,
      "used_by_stacks": ["qwen-1.7b", "qwen-0.6b", "vibevoice", "firered"]},
     {"package": "speaker-diarization-coreml", "environment": "swift", "bytes": 129243647,
-     "license_declared": "cc-by-4.0", "license_reviewed": true,
+     "state": "ready", "license_declared": "cc-by-4.0", "license_reviewed": true,
      "used_by_stacks": ["qwen-1.7b", "qwen-0.6b", "vibevoice", "firered"]},
     {"package": "qwen3-forcedaligner", "environment": "mlx", "bytes": 1276475979,
-     "license_declared": "apache-2.0", "license_reviewed": false,
+     "state": "ready", "license_declared": "apache-2.0", "license_reviewed": false,
      "used_by_stacks": ["qwen-1.7b", "qwen-0.6b", "vibevoice"]},
     {"package": "vibevoice-asr-7b", "environment": "torch-vibevoice", "bytes": 17349559904,
-     "license_declared": "mit", "license_reviewed": false,
+     "state": "ready", "license_declared": "mit", "license_reviewed": false,
      "used_by_stacks": ["vibevoice"]},
     {"package": "firered-asr2s", "environment": "torch-firered", "bytes": 9583893873,
-     "license_declared": "apache-2.0", "license_reviewed": false,
+     "state": "ready", "license_declared": "apache-2.0", "license_reviewed": false,
      "used_by_stacks": ["firered"]}
   ],
   "environments": {"mlx": "ready", "torch-firered": "ready", "torch-vibevoice": "ready",

--- a/TRANSCRIBE_HAPPY_PATH.md
+++ b/TRANSCRIBE_HAPPY_PATH.md
@@ -404,9 +404,11 @@ audio packages verify
   ],
   "environments": {"mlx": "ok", "swift": "ok", "torch-firered": "absent",
                    "torch-vibevoice": "absent"},
+  "mlx_audio_private_api_target": "mlx_audio/stt/models/qwen3_asr/qwen3_asr.py",
   "mlx_audio_private_api_expected_source_hash": "c082690575eedcd28fb76207d032cefd7eac2f9ce5d36df5a7a06575bc45d250",
   "mlx_audio_private_api_source_hash": "c082690575eedcd28fb76207d032cefd7eac2f9ce5d36df5a7a06575bc45d250",
   "mlx_audio_private_api_matches_expected": true,
+  "mlx_audio_private_api_signature_ok": true,
   "failed": []
 }
 ```

--- a/TRANSCRIBE_HAPPY_PATH.md
+++ b/TRANSCRIBE_HAPPY_PATH.md
@@ -411,7 +411,26 @@ audio packages verify
 }
 ```
 
-Exit 0. Which key an entry carries *is* the claim, and the two are not the same claim. `digest: "ok"`
+Exit 0. On the Swift-less machine above, the same command instead reports:
+
+```json
+{
+  "environments": {"mlx": "ok", "swift": "blocked", "torch-firered": "absent",
+                   "torch-vibevoice": "absent"}
+}
+```
+
+`blocked` rather than `ok`, and still exit 0. `speaker-diarization-coreml` needs no toolchain of
+its own, so it provisioned and left the `swift` environment `ready` in the registry — while
+nothing in that environment can run, because the built product is launched through `swift run`.
+`ok` there would tell a caller diarization is available on a machine that cannot do it. It is not
+a `failed` entry either: nothing provisioned is broken, the gap is a package `list` already
+reports as absent, and no `audio` command installs a toolchain for a `fix` to name. The registry
+state stays `ready` in `doctor` and `list`, which report what the registry holds and publish
+`blocked_by_missing_tool` beside it; only `verify` states a verdict, so only `verify` needed the
+fourth word. VOCABULARY.md has the two enumerations.
+
+Which key an entry carries *is* the claim, and the two are not the same claim. `digest: "ok"`
 means the bytes on disk were hashed and match the manifest's pin. `revision` means that revision is
 pinned and its snapshot is present — the pin is recorded and checkable, the contents were not
 hashed, and there is nothing to hash them against. The absent key is the honest report; a

--- a/TRANSCRIBE_HAPPY_PATH.md
+++ b/TRANSCRIBE_HAPPY_PATH.md
@@ -305,33 +305,44 @@ segments carry no `start`/`end` — in the sample above or in the real result be
 ### 1.3 Provision
 
 ```bash
-audio packages pull --stack qwen-1.7b \
-  --want diarization,word_timestamps
+audio packages pull --stack qwen-1.7b
 ```
+
+`pull` takes a stack or a list of package ids, and no `--want`: narrowing a stack to the
+capabilities actually requested is the planner's job, so passing it is refused rather than
+ignored — see the two refusals at the end of this section. A stack therefore provisions every
+package it can use, `silero-vad` included.
 
 Progress goes to stderr; stdout is the receipt:
 
 ```json
 {
   "pulled": [
+    {"package": "fluidaudio", "environment": "swift",
+     "revision": "19600a485baa4998812e4654b70d2bab8f2c9949",
+     "bytes": 471203840, "built": true, "product_runs": true},
     {"package": "qwen3-asr-1.7b-8bit", "environment": "mlx",
      "revision": "a8379a2e2f9e313c9292cdf1af4055ab56d50d55",
-     "bytes": 2463307541, "digest_verified": true},
-    {"package": "fluidaudio", "environment": "swift", "version": "0.15.5",
-     "revision": "19600a485baa4998812e4654b70d2bab8f2c9949",
-     "built": true, "product_runs": true},
-    {"package": "speaker-diarization-coreml", "environment": "swift",
-     "bytes": 84279296, "digest_verified": true, "license": "CC-BY-4.0"},
+     "bytes": 2467859030},
     {"package": "qwen3-forcedaligner", "environment": "mlx",
-     "bytes": 1932735283, "digest_verified": true}
+     "revision": "0e1a68e91d815300c7c9754b2a7639378b23db15",
+     "bytes": 1276475979},
+    {"package": "silero-vad", "environment": "core",
+     "bytes": 2327524, "digest_verified": true},
+    {"package": "speaker-diarization-coreml", "environment": "swift",
+     "revision": "1ed7a662fdc7109e36d822db793ee6eebdaf8594",
+     "bytes": 129243647}
   ],
+  "skipped": [],
   "environments_created": ["mlx", "swift"],
   "root": "/Users/you/Library/Caches/audio-processing-cli",
   "registry": "/Users/you/Library/Caches/audio-processing-cli/registry.json",
-  "pulled_known_bytes": 4480322120,
+  "pulled_known_bytes": 4347110020,
+  "unsized_packages": [],
   "warnings": [
     {"code": "license_unreviewed", "blocking": false,
-     "detail": "qwen3-asr-1.7b-8bit and qwen3-forcedaligner report license: \"unreviewed\"; only the FluidAudio SDK (Apache-2.0) and speaker-diarization-coreml (CC-BY-4.0) are recorded"}
+     "packages": ["qwen3-asr-1.7b-8bit", "qwen3-forcedaligner"],
+     "detail": "qwen3-asr-1.7b-8bit, qwen3-forcedaligner report a license their model card declares but nobody has reviewed. A declared license is evidence that one exists, not a redistribution clearance."}
   ]
 }
 ```
@@ -341,9 +352,42 @@ Exit 0. `pulled_known_bytes` covers the packages in *this* pull and nothing else
 down on a second, smaller pull. `audio packages list` reports the cumulative
 `total_known_bytes`.
 
+`digest_verified` appears on exactly one entry, and that is the point of it. `silero-vad` is
+pinned by content hash, so materializing it hashes the file against the manifest. The Hub packages
+are pinned by `revision`; there is no hash in the manifest to compare a snapshot against, so they
+report the revision they materialized and claim no digest. Every Hub entry used to carry
+`digest_verified: true` for a check no code performed.
+
+Run the same line twice and the second run does nothing: a package the registry already calls
+`ready` is listed under `skipped`, contributes no bytes, and is not touched — in particular it is
+not reopened as `pulling`, which an interrupt would leave behind as a downgraded install.
+`pull --repair <package>` is how a caller asks for the work anyway; it re-materializes rather than
+trusting what is on disk, which for a Hub snapshot means re-downloading it and for a checkout means
+discarding and re-cloning it.
+
 A package whose revision the shared Hugging Face cache already holds is not downloaded again. It
 reports `hub_revisions_pre_existing` in place of a fetch, and teardown will not delete it: see
 §5.
+
+On a machine with no Swift toolchain this same command exits 0 having provisioned everything else,
+and reports what it could not:
+
+```json
+{
+  "warnings": [
+    {"code": "toolchain_missing", "blocking": true,
+     "packages": ["fluidaudio"], "requires_tool": ["swift"],
+     "detail": "fluidaudio needs swift, which is not on PATH, so it was not provisioned; the rest of stack qwen-1.7b was. Install the toolchain and pull it by name."}
+  ]
+}
+```
+
+That is a `warnings` entry, not an error payload, which is what §0's promise about an absent
+`swift` — "reported rather than fatal, blocking only the packages that need it" — actually
+requires. `blocking: true` distinguishes it from `license_unreviewed`: something a caller asked
+for is absent. Exit 3 is reserved for two cases: a stack where *nothing* was provisionable, and a
+package named explicitly. Naming `fluidaudio` on the command line is an instruction, and skipping
+an instruction quietly is worse than refusing it.
 
 ```bash
 audio packages verify
@@ -352,10 +396,11 @@ audio packages verify
 ```json
 {
   "verified": [
-    {"package": "qwen3-asr-1.7b-8bit", "digest": "ok"},
     {"package": "fluidaudio", "product_runs": true, "patches_applied": []},
-    {"package": "speaker-diarization-coreml", "digest": "ok"},
-    {"package": "qwen3-forcedaligner", "digest": "ok"}
+    {"package": "qwen3-asr-1.7b-8bit", "revision": "a8379a2e2f9e313c9292cdf1af4055ab56d50d55"},
+    {"package": "qwen3-forcedaligner", "revision": "0e1a68e91d815300c7c9754b2a7639378b23db15"},
+    {"package": "silero-vad", "digest": "ok"},
+    {"package": "speaker-diarization-coreml", "revision": "1ed7a662fdc7109e36d822db793ee6eebdaf8594"}
   ],
   "environments": {"mlx": "ok", "swift": "ok", "torch-firered": "absent",
                    "torch-vibevoice": "absent"},
@@ -366,11 +411,55 @@ audio packages verify
 }
 ```
 
-Exit 0. `verify` reports every provisioned environment, not only the ones this pull touched, so the
+Exit 0. Which key an entry carries *is* the claim, and the two are not the same claim. `digest: "ok"`
+means the bytes on disk were hashed and match the manifest's pin. `revision` means that revision is
+pinned and its snapshot is present — the pin is recorded and checkable, the contents were not
+hashed, and there is nothing to hash them against. The absent key is the honest report; a
+`digest_verified: false` beside a `revision` would confess a check that was never designed rather
+than state the one that was. A four-repository package reports `revisions` for the same reason the
+receipt does: no one of them is *the* revision.
+
+`verify` reports every provisioned environment, not only the ones this pull touched, so the
 two `torch` environments appear as `absent` rather than being omitted — an environment missing from
 the map would be indistinguishable from one nobody has looked at. The private-API hash is published
 alongside the value it is compared against, because `matches_expected: true` on its own is a claim
 a reader cannot check.
+
+Two ways of asking for a pull are refused, both exit 2, and both are refusals of a *silently
+ignored argument* rather than of an unsupported idea:
+
+```bash
+audio packages pull --stack qwen-1.7b --want diarization,word_timestamps
+```
+
+```json
+{
+  "code": "want_not_implemented",
+  "field": "--want",
+  "provided": "diarization,word_timestamps",
+  "detail": "capabilities cannot narrow a pull yet: resolving them to packages is the planner's job, so --stack qwen-1.7b provisions every package it can use",
+  "fix": "audio packages pull --stack qwen-1.7b"
+}
+```
+
+```bash
+audio packages pull --stack qwen-1.7b silero-vad
+```
+
+```json
+{
+  "code": "stack_conflicts_with_named_packages",
+  "stack": "qwen-1.7b",
+  "packages": ["silero-vad"],
+  "detail": "--stack qwen-1.7b was passed alongside named packages; a stack selects every package it can use and named ids select exactly those, so one of the two has to go",
+  "fix": "audio packages pull silero-vad"
+}
+```
+
+`--want` was accepted and dropped on the floor until this pass, and so was `--stack` beside a list
+of ids. Both are the failure §4.6 names for `transcribe`: a caller would believe it had constrained
+a 4 GiB download it never touched. The `fix` keeps the argument that was an instruction and drops
+the one that was a guess.
 
 ### 1.4 Run
 
@@ -584,8 +673,7 @@ here detects overlap is what says it cannot fill.
 ### 2.2 Provision and run
 
 ```bash
-audio packages pull --stack vibevoice \
-  --want verbatim,diarization,segment_timestamps,word_timestamps
+audio packages pull --stack vibevoice
 audio transcribe run --input demo.mp4 --stack vibevoice \
   --want verbatim,diarization,segment_timestamps,word_timestamps \
   --format json -o demo.transcript.json
@@ -778,8 +866,7 @@ Exit 0. Segments carry no `speaker` key in the sample or the result: FireRed has
 speaker output and `diarization` was not requested.
 
 ```bash
-audio packages pull --stack firered \
-  --want verbatim,word_timestamps,vad,segment_timestamps,lid
+audio packages pull --stack firered
 audio transcribe run --input field.wav --stack firered \
   --want verbatim,word_timestamps,vad,segment_timestamps,lid \
   --format json -o field.transcript.json
@@ -1058,7 +1145,7 @@ pin to select among. Pins choose between implementations of a role that exists.
 
 | Code | Exit | Trigger | What `fix` says |
 | --- | --- | --- | --- |
-| `packages_not_provisioned` | 3 | `run` before `pull` | The exact `audio packages pull` line for this stack and want set |
+| `packages_not_provisioned` | 3 | `run` before `pull` | The `audio packages pull --stack` line for this stack — every package it can use, since narrowing a pull to a want set is reserved for the planner |
 | `package_integrity_failed` | 3 | a digest, size, or revision mismatch on something already provisioned | `audio packages pull --repair <package>` |
 | `timing_required_for_format` | 2 | `export --format srt` on a transcript with no word timing | The `transcribe run` line that would produce timing, with `word_timestamps` added |
 | `run_incomplete` | 4 | budget exhausted, or a stage died part-way on a partitioned stack | The `--range <watermark>:` line that transcribes only what is missing |
@@ -1068,6 +1155,10 @@ The last row is the honest exception. Everything above it has a correction the t
 compute; a crash does not, so `fix` proposes rather than instructs, and the payload says
 which `role` and `backend` failed so a caller can tell a memory ceiling from a missing
 toolchain.
+
+Two further refusals belong to `audio packages pull` rather than to `transcribe`, and §1.3
+publishes both: `want_not_implemented` and `stack_conflicts_with_named_packages`, each exit 2 and
+each a refusal of an argument that used to be accepted and ignored.
 
 ## 5. Teardown
 

--- a/TRANSCRIBE_HAPPY_PATH.md
+++ b/TRANSCRIBE_HAPPY_PATH.md
@@ -1245,6 +1245,11 @@ audio packages remove vibevoice-asr-7b
 }
 ```
 
+`remove` takes several names, and it is all-or-nothing: every name is resolved against the
+registry before anything is deleted, so a typo among four ids costs nothing but the retry. It used
+to delete as it went and then roll the registry back, which left a package whose bytes were gone
+still reading as `ready`.
+
 Reference counting cuts both ways here, which is the point of showing it: `torch-vibevoice`
 held exactly one package and dies with it, while `mlx` survives because the aligner and the
 ASR checkpoint are still provisioned there. The count is derived from the package table each

--- a/VOCABULARY.md
+++ b/VOCABULARY.md
@@ -496,10 +496,46 @@ Rules:
   whether tracked patches are applied, and that the Swift product runs.
 
 Lifecycle: `audio packages list | pull | verify | remove | purge | path`. `pull`
-accepts package ids, or the same `--stack` and `--want` arguments `transcribe`
-takes so the provisioning set comes from the plan rather than from memorized ids.
-`path` prints the resolved root and per-package locations so a session with no
-provisioning history can still locate everything.
+accepts package ids **or** `--stack`, never both, and it does not accept `--want`:
+narrowing a stack to the capabilities a plan actually uses belongs to the planner
+(#12), so until that exists a stack provisions every package it can use and the flag
+is refused rather than accepted and ignored. `path` prints the resolved root and
+per-package locations so a session with no provisioning history can still locate
+everything.
+
+### States, and which command publishes which
+
+Two enumerations, and they are not the same enumeration. Conflating them is what let an
+unusable environment read as a working one.
+
+**Registry state**, recorded in `registry.json` and republished verbatim by `doctor`,
+`packages list`, and `packages path`. A package is `pulling` then `ready`; an environment is
+`creating` then `ready`; either is **absent** by having no entry at all. Intent is written
+before any bytes move, so a crashed `pull` is nameable, and anything not `ready` counts as
+absent to a run and as reclaimable to `purge`.
+
+**Verify verdict**, published only by `packages verify`, one per provisioned environment:
+
+| Verdict | Means |
+| --- | --- |
+| `ok` | every check that applies to this environment passed. |
+| `drifted` | its installed set differs from its lock. Repairable: `verify --repair` re-syncs it. |
+| `blocked` | a tool in its `requires_tool` is not on `PATH`, so nothing in it can run whatever the registry holds. Not repairable by this tool — installing a toolchain is not something `audio` does. |
+| `absent` | this root has not provisioned it. |
+
+`blocked` exists because the two enumerations answer different questions and only the second
+one is a claim about usability. A stack pull provisions the packages that need no toolchain and
+reports the blocked one, so `swift` can legitimately be `ready` in the registry while holding
+nothing that can execute — `doctor` says so by publishing `blocked_by_missing_tool` beside the
+state, and a bare `ok` from `verify` cannot. The word is the one this tool already uses for the
+condition, in `doctor`'s `blocked_by_missing_tool` and in a pull warning's `blocking: true`; it
+is not a new concept, only a missing spelling.
+
+A registry-state field is **not** restated as `blocked`. It reports what the registry holds,
+which is a different and still-useful fact, and three commands publish it — rewriting one of
+them would leave the other two disagreeing while nothing published the registry's own field.
+Which tool is missing is static per environment (`requires_tool` is manifest data), so `verify`
+keeps a flat enum a caller can switch on rather than an object restating it.
 
 ## Retired and reserved words
 

--- a/src/audio_cli/cli.py
+++ b/src/audio_cli/cli.py
@@ -46,6 +46,11 @@ def _parser() -> argparse.ArgumentParser:
     inspect_parser.add_argument(
         "--report", type=Path, help="Also write the JSON inspection here."
     )
+    inspect_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace an existing report.",
+    )
 
     enhance_parser = subparsers.add_parser(
         "enhance",
@@ -98,7 +103,7 @@ def _parser() -> argparse.ArgumentParser:
     pull_parser.add_argument("--stack", help="Provision what this stack can use.")
     pull_parser.add_argument(
         "--want",
-        help="Capabilities, for symmetry with transcribe. Reserved until the planner lands.",
+        help="Reserved until the planner lands, and refused until then rather than ignored.",
     )
     pull_parser.add_argument(
         "--repair",
@@ -143,11 +148,13 @@ def _ensure_writable_target(path: Path | None, *, force: bool, label: str) -> No
 
 
 def _run_inspect(args: argparse.Namespace) -> int:
+    # Checked before any work, the way `enhance` checks it: the analysis decodes the file and runs
+    # speech detection over it, and refusing the destination afterwards throws all of that away.
+    _ensure_writable_target(args.report, force=args.force, label="Report")
     profile = get_profile(args.profile) if args.profile else None
     detector = SileroOnnxVad(args.vad_model)
     report = inspect_source(args.input, profile=profile, detector=detector)
     if args.report:
-        _ensure_writable_target(args.report, force=False, label="Report")
         write_report(args.report, report)
     _print_json(report)
     return 0
@@ -229,10 +236,22 @@ def _run_packages(args: argparse.Namespace) -> int:
         if args.want and not args.stack:
             raise ProvisioningError(
                 "stack_required", "--want needs --stack: capabilities are resolved per stack",
-                exit_code=2, fix="audio packages pull --stack <stack> --want <capabilities>",
+                exit_code=2, fix="audio packages pull --stack <stack>",
+            )
+        if args.want:
+            # Refused rather than ignored. Nothing downstream of here reads `--want`: resolving
+            # capabilities to a package set is the planner's job (#12), and a stack still
+            # provisions every package it can use. Accepting the flag silently would be the real
+            # failure — a caller would believe it had narrowed a 17 GiB download it never touched.
+            raise ProvisioningError(
+                "want_not_implemented",
+                "capabilities cannot narrow a pull yet: resolving them to packages is the "
+                f"planner's job, so --stack {args.stack} provisions every package it can use",
+                exit_code=2, field="--want", provided=args.want,
+                fix=f"audio packages pull --stack {args.stack}",
             )
         selection = select(args.packages, stack=args.stack)
-        _print_json(provisioner.pull(selection))
+        _print_json(provisioner.pull(selection, repair=args.repair, stack=args.stack))
         return 0
     if command == "verify":
         report = provisioner.verify(repair=args.repair)

--- a/src/audio_cli/environments/manifest.json
+++ b/src/audio_cli/environments/manifest.json
@@ -8,7 +8,6 @@
     "revisions": "Recovered from the recorded runs: .cache/huggingface/download/*.metadata under each local model directory, and the hub snapshot directories for the MLX checkpoints."
   },
   "license_policy": "license_declared is what the model card says at the pinned revision. license_reviewed stays false until someone reads the terms; a declared license is evidence that one exists, not a redistribution clearance. `audio packages list` reports both.",
-
   "environments": {
     "core": {
       "provisioned": false,
@@ -33,7 +32,15 @@
         {
           "kind": "signature",
           "target": "mlx_audio.stt.models.qwen3_asr.qwen3_asr.Qwen3ASRModel._generate_chunks_batched",
-          "required_parameters": ["chunks", "max_tokens", "sampler", "language", "system_prompt", "batch_size", "verbose"],
+          "required_parameters": [
+            "chunks",
+            "max_tokens",
+            "sampler",
+            "language",
+            "system_prompt",
+            "batch_size",
+            "verbose"
+          ],
           "checkable_without_weights": true
         }
       ]
@@ -58,17 +65,24 @@
       "provisioned": true,
       "python": null,
       "lock": null,
-      "requires_tool": ["swift"],
+      "requires_tool": [
+        "swift"
+      ],
       "reason": "A Swift build product plus one Core ML model package. No interpreter, so no lock; absent `swift` blocks only these packages and is reported by `audio doctor` rather than being fatal."
     }
   },
-
   "packages": {
     "silero-vad": {
       "environment": "core",
       "kind": "weights",
-      "roles": ["vad"],
-      "stacks": ["qwen-1.7b", "qwen-0.6b", "vibevoice"],
+      "roles": [
+        "vad"
+      ],
+      "stacks": [
+        "qwen-1.7b",
+        "qwen-0.6b",
+        "vibevoice"
+      ],
       "bytes": 2327524,
       "license_declared": "mit",
       "license_reviewed": true,
@@ -86,8 +100,12 @@
     "qwen3-asr-1.7b-8bit": {
       "environment": "mlx",
       "kind": "weights",
-      "roles": ["asr"],
-      "stacks": ["qwen-1.7b"],
+      "roles": [
+        "asr"
+      ],
+      "stacks": [
+        "qwen-1.7b"
+      ],
       "bytes": 2467859030,
       "license_declared": "apache-2.0",
       "license_reviewed": false,
@@ -100,8 +118,12 @@
     "qwen3-asr-0.6b-8bit": {
       "environment": "mlx",
       "kind": "weights",
-      "roles": ["asr"],
-      "stacks": ["qwen-0.6b"],
+      "roles": [
+        "asr"
+      ],
+      "stacks": [
+        "qwen-0.6b"
+      ],
       "bytes": 1010773761,
       "license_declared": "apache-2.0",
       "license_reviewed": false,
@@ -114,8 +136,14 @@
     "qwen3-forcedaligner": {
       "environment": "mlx",
       "kind": "weights",
-      "roles": ["aligner"],
-      "stacks": ["qwen-1.7b", "qwen-0.6b", "vibevoice"],
+      "roles": [
+        "aligner"
+      ],
+      "stacks": [
+        "qwen-1.7b",
+        "qwen-0.6b",
+        "vibevoice"
+      ],
       "bytes": 1276475979,
       "license_declared": "apache-2.0",
       "license_reviewed": false,
@@ -129,14 +157,18 @@
         "revision": "c7cbfc2048c462b0d63a45797104fc9db3ad62b7",
         "bytes": 1840072459,
         "environment_was": "a PyTorch environment via the qwen-asr package",
-        "evidence": "model_tests/benchmark/results/2026-08-17-mlx-collapse-probes.json — identical token text on all 246 aligned tokens across all 17 word-bearing segments, no punctuation-invariant violations, bound agreement median 0 s with P95 80 ms and max 1.6 s."
+        "evidence": "model_tests/benchmark/results/2026-08-17-mlx-collapse-probes.json \u2014 identical token text on all 246 aligned tokens across all 17 word-bearing segments, no punctuation-invariant violations, bound agreement median 0 s with P95 80 ms and max 1.6 s."
       }
     },
     "vibevoice-asr-7b": {
       "environment": "torch-vibevoice",
       "kind": "weights",
-      "roles": ["asr"],
-      "stacks": ["vibevoice"],
+      "roles": [
+        "asr"
+      ],
+      "stacks": [
+        "vibevoice"
+      ],
       "bytes": 17349559904,
       "license_declared": "mit",
       "license_reviewed": false,
@@ -164,18 +196,45 @@
     "firered-asr2s": {
       "environment": "torch-firered",
       "kind": "weights",
-      "roles": ["vad", "lid", "asr", "punctuator"],
-      "stacks": ["firered"],
+      "roles": [
+        "vad",
+        "lid",
+        "asr",
+        "punctuator"
+      ],
+      "stacks": [
+        "firered"
+      ],
       "bytes": 9583893873,
       "license_declared": "apache-2.0",
       "license_reviewed": false,
       "source": {
         "type": "huggingface_multi",
         "repos": [
-          {"role": "asr", "repo": "FireRedTeam/FireRedASR2-AED", "revision": "2304afed56eacfee6256dee5937ed22ffa0b64ec", "bytes": 4731895352},
-          {"role": "lid", "repo": "FireRedTeam/FireRedLID", "revision": "1bb4d285c8456429385d9c0810300df4297bc11b", "bytes": 3550109871},
-          {"role": "punctuator", "repo": "FireRedTeam/FireRedPunc", "revision": "e448fd967f44182a1c323cc30f5d89f2400c28da", "bytes": 1294853603},
-          {"role": "vad", "repo": "FireRedTeam/FireRedVAD", "revision": "7990aaccc6b7aec1e527743bd30201f2c4a03b8c", "bytes": 7035047}
+          {
+            "role": "asr",
+            "repo": "FireRedTeam/FireRedASR2-AED",
+            "revision": "2304afed56eacfee6256dee5937ed22ffa0b64ec",
+            "bytes": 4731895352
+          },
+          {
+            "role": "lid",
+            "repo": "FireRedTeam/FireRedLID",
+            "revision": "1bb4d285c8456429385d9c0810300df4297bc11b",
+            "bytes": 3550109871
+          },
+          {
+            "role": "punctuator",
+            "repo": "FireRedTeam/FireRedPunc",
+            "revision": "e448fd967f44182a1c323cc30f5d89f2400c28da",
+            "bytes": 1294853603
+          },
+          {
+            "role": "vad",
+            "repo": "FireRedTeam/FireRedVAD",
+            "revision": "7990aaccc6b7aec1e527743bd30201f2c4a03b8c",
+            "bytes": 7035047
+          }
         ]
       },
       "checkout": {
@@ -189,27 +248,44 @@
     "fluidaudio": {
       "environment": "swift",
       "kind": "toolchain",
-      "roles": ["diarizer"],
-      "stacks": ["qwen-1.7b", "qwen-0.6b", "vibevoice", "firered"],
+      "roles": [
+        "diarizer"
+      ],
+      "stacks": [
+        "qwen-1.7b",
+        "qwen-0.6b",
+        "vibevoice",
+        "firered"
+      ],
       "bytes": null,
       "unsized_because": "A Swift build product, whose size depends on the toolchain that builds it. pull records the measured size afterwards.",
       "license_declared": "apache-2.0",
       "license_reviewed": true,
       "license_source": "model_tests/benchmark/DIARIZATION.md",
-      "requires_tool": ["swift"],
+      "requires_tool": [
+        "swift"
+      ],
       "source": {
         "type": "git+build",
         "repo": "https://github.com/FluidInference/FluidAudio.git",
         "version": "0.15.5",
-        "commit": "19600a485baa4998812e4654b70d2bab8f2c9949"
+        "commit": "19600a485baa4998812e4654b70d2bab8f2c9949",
+        "product": "fluidaudiocli"
       },
       "note": "Also ships a Core ML VAD that its own VadManager resolves. That is not a named package here: the comparison probe exercised it, but this tool has never provisioned it. If --vad fluidaudio ships, it becomes one and gets its own entry."
     },
     "speaker-diarization-coreml": {
       "environment": "swift",
       "kind": "weights",
-      "roles": ["diarizer"],
-      "stacks": ["qwen-1.7b", "qwen-0.6b", "vibevoice", "firered"],
+      "roles": [
+        "diarizer"
+      ],
+      "stacks": [
+        "qwen-1.7b",
+        "qwen-0.6b",
+        "vibevoice",
+        "firered"
+      ],
       "bytes": 129243647,
       "license_declared": "cc-by-4.0",
       "license_reviewed": true,

--- a/src/audio_cli/media.py
+++ b/src/audio_cli/media.py
@@ -402,13 +402,18 @@ def temporary_output_path(output: Path) -> Iterator[Path]:
 
 
 def atomic_write_json(path: Path, payload: dict[str, object]) -> None:
+    """Written through a sibling and renamed, so a report is never observed half-written.
+
+    Deliberately a plain `open` rather than `mkstemp`. `mkstemp` creates 0600 and `os.replace`
+    carries that mode onto the destination, so a report arrived stricter than the render it
+    describes -- 0600 beside an 0644 wav, under the same umask, for no reason a reader could act
+    on. Everything else this tool publishes honours the umask, including `save_registry`, which
+    reached the same conclusion by writing the same way.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, raw = tempfile.mkstemp(
-        prefix=f".{path.name}-", suffix=".tmp", dir=path.parent
-    )
-    temp = Path(raw)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        with temp.open("w", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, sort_keys=True, ensure_ascii=False)
             handle.write("\n")
         os.replace(temp, path)

--- a/src/audio_cli/media.py
+++ b/src/audio_cli/media.py
@@ -156,6 +156,12 @@ def decode_audio(path: Path, *, sample_rate: int = 48_000) -> tuple[np.ndarray, 
     return samples.reshape((-1, channels)), sample_rate
 
 
+def _wav_duration_ms(path: Path) -> float:
+    """Duration of a wav this tool wrote, read through the header rather than the samples."""
+    rate, data = wavfile.read(path, mmap=True)
+    return len(data) / float(rate) * 1000.0
+
+
 def write_float_wav(path: Path, samples: np.ndarray, sample_rate: int) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     wavfile.write(path, sample_rate, np.asarray(samples, dtype=np.float32))
@@ -225,7 +231,21 @@ def render_loudness_normalized(
 ) -> dict[str, object]:
     required = ("input_i", "input_lra", "input_tp", "input_thresh")
     if any(not math.isfinite(measurement.get(key, math.nan)) for key in required):
-        raise MediaError("Cannot normalize silent or non-finite audio")
+        # Two different conditions, and reporting them as one sent anyone with a short clip
+        # looking for silence that was not there. A finite true peak is the evidence that the
+        # signal exists: integrated loudness is gated in 400 ms blocks (EBU R128), so anything
+        # shorter has no measurable value however loud it is, while true silence has no finite
+        # peak either.
+        peak = measurement.get("input_tp", math.nan)
+        if math.isfinite(peak):
+            raise MediaError(
+                f"Cannot normalize {_wav_duration_ms(source_wav):.0f} ms of audio: integrated "
+                f"loudness is measured over 400 ms gating blocks (EBU R128), so a shorter input "
+                f"has none however loud it is. This input peaks at {peak:.2f} dBTP, so it is not "
+                f"silent -- it is too short to measure. Enhance a longer excerpt, or skip "
+                f"program-loudness with --skip program-loudness."
+            )
+        raise MediaError("Cannot normalize silent audio: it has no measurable level or peak")
     gain_db = target_lufs - measurement["input_i"]
     limiter_amplitude = 10.0 ** (target_true_peak / 20.0)
     iterations: list[dict[str, float]] = []

--- a/src/audio_cli/packages.py
+++ b/src/audio_cli/packages.py
@@ -211,8 +211,14 @@ class Fetcher:
             return set()
         return {revision.commit_hash for repo in cache.repos for revision in repo.revisions}
 
-    def hf_snapshot(self, repo: str, revision: str) -> Path:
-        """Materialize a revision into the shared Hub cache, resuming a partial download."""
+    def hf_snapshot(self, repo: str, revision: str, *, force: bool = False) -> Path:
+        """Materialize a revision into the shared Hub cache, resuming a partial download.
+
+        `force` re-downloads what the cache already holds, and it is what makes `pull --repair`
+        mean anything for a Hub package: without it `snapshot_download` sees the revision present
+        and returns the snapshot unchanged, so a repair of a corrupt snapshot would report success
+        having moved no bytes.
+        """
         try:
             from huggingface_hub import snapshot_download
         except ImportError as exc:  # noqa: BLE001 - reported, not swallowed
@@ -222,7 +228,7 @@ class Fetcher:
                 missing_tool="huggingface_hub",
                 fix="uv pip install huggingface_hub",
             ) from exc
-        return Path(snapshot_download(repo, revision=revision))
+        return Path(snapshot_download(repo, revision=revision, force_download=force))
 
     def delete_hub_revisions(self, revisions: list[str]) -> tuple[list[str], int]:
         """Delete exactly these revisions from the Hub cache. Returns what went, and its size.
@@ -353,8 +359,21 @@ def select(package_ids: list[str] | None = None, *, stack: str | None = None) ->
     `pull --stack S --want ...` is meant to take its set from a plan. Until the planner exists
     (#12), a stack selects every package that lists it, which over-provisions rather than
     under-provisions — the failure that would matter here is a missing package at run time.
+
+    The two forms are alternatives rather than layers, so passing both is refused instead of
+    resolved by precedence. This function used to return the named packages and drop `--stack` on
+    the floor, which is the same defect as a silently ignored `--want`: the caller reads a receipt
+    for a set it did not ask for and cannot tell which input was honoured.
     """
     catalog = packages()
+    if package_ids and stack is not None:
+        raise ProvisioningError(
+            "stack_conflicts_with_named_packages",
+            f"--stack {stack} was passed alongside named packages; a stack selects every package "
+            "it can use and named ids select exactly those, so one of the two has to go",
+            exit_code=2, stack=stack, packages=list(package_ids),
+            fix=f"audio packages pull {' '.join(package_ids)}",
+        )
     if package_ids:
         unknown = sorted(set(package_ids) - set(catalog))
         if unknown:
@@ -500,24 +519,53 @@ class Provisioner:
 
     # -- packages ----------------------------------------------------------------------
 
-    def pull(self, selection: list[Package]) -> dict:
+    def pull(self, selection: list[Package], *, repair: bool = False,
+             stack: str | None = None) -> dict:
+        """Materialize what is not already provisioned. Two asymmetries, both deliberate.
+
+        **A `ready` package is skipped, not re-materialized.** Re-hashing a multi-gigabyte
+        artifact, re-cloning and re-installing a checkout, or rebuilding the Swift product costs
+        minutes and produces what is already there. Worse, the `pulling` entry that has to be
+        written first would leave a working install downgraded if the pointless re-pull were
+        interrupted — the crash-safety rule turned against a package nothing was wrong with.
+        `--repair` is how a caller asks for the work anyway, and it *forces* re-materialization
+        rather than trusting what is on disk, because a corrupt-but-present artifact is exactly
+        the case it exists for.
+
+        **A stack tolerates a toolchain-blocked package; a named one does not.** `--stack` is a
+        superset guess, so an absent `swift` blocks `fluidaudio` and the rest of the stack still
+        provisions, with the blocked package reported in `warnings` — which is what
+        TRANSCRIBE_HAPPY_PATH.md §0 promises and what raising on the first blocked package broke,
+        since `fluidaudio` sorts first and took the whole stack down with it. Naming a package is
+        an instruction, so there the missing tool is still exit 3: silently skipping what a caller
+        asked for by name is worse than refusing.
+        """
         document = load_registry()
         # Read the cache once, before anything downloads. Everything after this point works
         # from that snapshot, so a revision fetched by this pull is never mistaken for one that
         # was already there.
         cached = self.fetcher.cached_revisions()
         pulled: list[dict] = []
+        skipped: list[str] = []
         created: list[str] = []
         warnings: list[dict] = []
+        blocked: list[tuple[Package, str]] = []
 
         for package in selection:
-            for tool in package.requires_tool:
-                if self.toolchain.which(tool) is None:
-                    raise ProvisioningError(
-                        "toolchain_missing",
-                        f"{package.id} needs {tool}, which is not on PATH",
-                        missing_tool=tool, package=package.id, requires_tool=[tool],
-                    )
+            if not repair and is_ready(document, package.id):
+                # Nothing needs doing, so nothing is touched — in particular the entry is not
+                # transitioned to `pulling`, which an interrupted no-op would leave behind.
+                skipped.append(package.id)
+                continue
+
+            missing_tool = next((tool for tool in package.requires_tool
+                                 if self.toolchain.which(tool) is None), None)
+            if missing_tool is not None:
+                if stack is None:
+                    raise _toolchain_missing(package, missing_tool)
+                blocked.append((package, missing_tool))
+                continue
+
             if self.ensure_environment(package.environment, document):
                 created.append(package.environment)
 
@@ -534,7 +582,7 @@ class Provisioner:
             document["packages"][package.id] = entry
             save_registry(document)
 
-            materialized = self._materialize(package, document, pre_existing)
+            materialized = self._materialize(package, document, pre_existing, repair=repair)
             entry["materialized"] = materialized
             entry["state"] = "ready"
             document["packages"][package.id] = entry
@@ -555,7 +603,32 @@ class Provisioner:
                 )
             pulled.append(receipt)
 
-        unreviewed = sorted(p.id for p in selection if not p.license_reviewed)
+        if blocked and not pulled and not skipped:
+            # Nothing in the stack was provisionable, so there is no partial success to report
+            # and the caller needs the exit code rather than a receipt of an empty pull.
+            raise _toolchain_missing(*blocked[0])
+
+        if blocked:
+            tools = sorted({tool for _, tool in blocked})
+            names = [package.id for package, _ in blocked]
+            warnings.append({
+                "code": "toolchain_missing", "blocking": True,
+                "packages": names, "requires_tool": tools,
+                "detail": (
+                    f"{', '.join(names)} {'needs' if len(names) == 1 else 'need'} "
+                    f"{', '.join(tools)}, which {'is' if len(tools) == 1 else 'are'} not on "
+                    f"PATH, so {'it' if len(names) == 1 else 'they'} "
+                    f"{'was' if len(names) == 1 else 'were'} not provisioned; the rest of "
+                    f"{f'stack {stack}' if stack else 'the selection'} was. Install the "
+                    f"toolchain and pull {'it' if len(names) == 1 else 'them'} by name."
+                ),
+            })
+
+        # A blocked package provisioned nothing, so it carries no license claim and no bytes.
+        # `pulled_known_bytes` says what this pull added, and a skipped package added none of it.
+        blocked_ids = {package.id for package, _ in blocked}
+        provisioned = [p for p in selection if p.id not in blocked_ids]
+        unreviewed = sorted(p.id for p in provisioned if not p.license_reviewed)
         if unreviewed:
             warnings.append({
                 "code": "license_unreviewed", "blocking": False,
@@ -568,9 +641,11 @@ class Provisioner:
                 ),
             })
 
-        known, unsized = _selection_bytes(selection, document)
-        return {
+        known, unsized = _selection_bytes(
+            [p for p in provisioned if p.id not in set(skipped)], document)
+        report = {
             "pulled": pulled,
+            "skipped": skipped,
             "environments_created": sorted(set(created)),
             "root": str(paths.root()),
             "registry": str(paths.registry_path()),
@@ -581,6 +656,13 @@ class Provisioner:
             "unsized_packages": unsized,
             "warnings": warnings,
         }
+        if skipped:
+            report["skipped_reason"] = (
+                "already ready in the registry, so nothing was re-materialized and nothing "
+                "counts toward pulled_known_bytes; audio packages pull --repair <package> "
+                "re-materializes anyway, and audio packages verify is what checks them"
+            )
+        return report
 
     @staticmethod
     def _pre_existing_revisions(package: Package, previous: dict,
@@ -602,14 +684,26 @@ class Provisioner:
             return set(previous["hub_revisions_pre_existing"])
         return {revision for revision in _source_revisions(package) if revision in cached}
 
-    def _materialize(self, package: Package, document: dict,
-                     pre_existing: set[str]) -> dict:
+    def _materialize(self, package: Package, document: dict, pre_existing: set[str], *,
+                     repair: bool = False) -> dict:
+        """Put the package on disk. `digest_verified` appears only where a digest was taken.
+
+        One source kind pins a content hash — `url` — and it is the only one whose materialization
+        can claim to have been verified against the manifest. The Hub kinds pin a *revision*; no
+        `sha256` exists in the manifest to hash a snapshot against, so they record the revision
+        and nothing more. They used to record `digest_verified: True` regardless, which made
+        `verify` print `digest: "ok"` for a check no code performs.
+        """
         kind = package.source["type"]
         if kind == "url":
             # The filename is manifest data, not derived: the shipped Silero backend resolves
             # this exact name, and a pull that invented one would leave two copies on disk and
             # re-download on first use. tests/test_environments.py ties the two together.
             target = paths.models_dir() / package.source["filename"]
+            # `repair` needs no force here, and the digest is the reason: url_file re-hashes what
+            # is on disk against the manifest pin and downloads again unless it matches, so a
+            # match already is the strongest re-materialization available. Forcing the transfer
+            # would spend the bytes to arrive at the same file.
             resolved = self.fetcher.url_file(package.source["url"], package.source["sha256"],
                                              target)
             return {"path": str(resolved), "bytes": _tree_bytes(resolved),
@@ -617,16 +711,16 @@ class Provisioner:
 
         if kind == "huggingface":
             revision = package.source["revision"]
-            snapshot = self.fetcher.hf_snapshot(package.source["repo"], revision)
+            snapshot = self.fetcher.hf_snapshot(package.source["repo"], revision, force=repair)
             result = {
                 "path": str(snapshot), "bytes": _tree_bytes(snapshot),
-                "revision": revision, "digest_verified": True,
+                "revision": revision,
                 # Only what this pull fetched is ours to delete later, decided before the
                 # download rather than after it — see _pre_existing_revisions.
                 "hub_revisions": [] if revision in pre_existing else [revision],
                 "hub_revisions_pre_existing": sorted(pre_existing),
             }
-            result.update(self._checkout_and_install(package))
+            result.update(self._checkout_and_install(package, repair=repair))
             return result
 
         if kind == "huggingface_multi":
@@ -634,24 +728,29 @@ class Provisioner:
             total = 0
             ours: list[str] = []
             for repo in package.source["repos"]:
-                snapshot = self.fetcher.hf_snapshot(repo["repo"], repo["revision"])
+                snapshot = self.fetcher.hf_snapshot(repo["repo"], repo["revision"],
+                                                    force=repair)
                 snapshots[repo["repo"]] = str(snapshot)
                 total += _tree_bytes(snapshot)
                 if repo["revision"] not in pre_existing:
                     ours.append(repo["revision"])
             result = {
-                "paths": snapshots, "bytes": total, "digest_verified": True,
+                "paths": snapshots, "bytes": total,
                 # Plural, because this package spans four repositories. A single `revision`
                 # key would have to pick one of them, and the receipt promises the revisions
                 # a pull materialized.
                 "revisions": [repo["revision"] for repo in package.source["repos"]],
                 "hub_revisions": ours, "hub_revisions_pre_existing": sorted(pre_existing),
             }
-            result.update(self._checkout_and_install(package))
+            result.update(self._checkout_and_install(package, repair=repair))
             return result
 
         if kind == "git+build":
             checkout = paths.checkout_dir(package.environment, package.id)
+            if repair:
+                # Rebuilding in place would trust the checkout whose state is what is in doubt:
+                # `clone` skips an existing directory, so a dirty or half-built tree survives.
+                _delete(checkout)
             checkout.parent.mkdir(parents=True, exist_ok=True)
             self.toolchain.clone(package.source["repo"], package.source["commit"], checkout)
             self.toolchain.swift_build(checkout)
@@ -661,11 +760,15 @@ class Provisioner:
 
         raise ManifestError(f"{package.id}: unsupported source type {kind!r}")
 
-    def _checkout_and_install(self, package: Package) -> dict:
+    def _checkout_and_install(self, package: Package, *, repair: bool = False) -> dict:
         """Pinned source checkout, patch, and a --no-deps install into the environment."""
         if package.checkout is None:
             return {}
         checkout = paths.checkout_dir(package.environment, package.id)
+        if repair:
+            # Same reason as the Swift build: a repair of `patch_not_applied` must not re-patch a
+            # tree that may also be at the wrong commit. Re-clone, then patch.
+            _delete(checkout)
         checkout.parent.mkdir(parents=True, exist_ok=True)
         self.toolchain.clone(package.checkout["repo"], package.checkout["commit"], checkout)
 
@@ -740,6 +843,7 @@ class Provisioner:
             package = catalog.get(identifier)
             record: dict = {"package": identifier}
             materialized = entry.get("materialized", {})
+            # `digest: "ok"` is reserved for the one kind that has something to hash against.
             if package is not None and package.source["type"] == "url":
                 location = Path(materialized.get("path", ""))
                 if location.is_file() and sha256_file(location) == package.source["sha256"]:
@@ -769,7 +873,7 @@ class Provisioner:
                         "fix": f"audio packages pull --repair {identifier}",
                     })
                     continue
-                record["digest"] = "ok" if materialized.get("digest_verified") else "unverified"
+                record.update(_pinned_revisions(materialized))
 
             digests = materialized.get("patched_file_digests") or {}
             if digests:
@@ -1096,6 +1200,31 @@ def _patched_files(patch: Path, checkout: Path) -> list[Path]:
     return touched
 
 
+def _toolchain_missing(package: Package, tool: str) -> ProvisioningError:
+    """The exit-3 refusal for a package whose external toolchain is absent."""
+    return ProvisioningError(
+        "toolchain_missing", f"{package.id} needs {tool}, which is not on PATH",
+        missing_tool=tool, package=package.id, requires_tool=[tool],
+    )
+
+
+def _pinned_revisions(materialized: dict) -> dict:
+    """What a Hub package's `verify` entry can honestly claim, which is not a digest.
+
+    Nothing here hashes a snapshot. The manifest pins a revision and carries no `sha256` for a Hub
+    source, so there is nothing to hash *against*; a `digest` key would name a check no code
+    performs. The revision is what is pinned, and the existence check above it is the rest of what
+    was verified. So the two claims are told apart by which key is present — `digest` where
+    contents were hashed against a manifest pin, `revision`/`revisions` where a revision is pinned
+    and the snapshot is present — rather than by a `digest_verified: false` confession.
+    """
+    if "revision" in materialized:
+        return {"revision": materialized["revision"]}
+    if "revisions" in materialized:
+        return {"revisions": list(materialized["revisions"])}
+    return {}
+
+
 def _source_revisions(package: Package) -> list[str]:
     """Every Hub revision a package pins, whether it names one or four."""
     source = package.source
@@ -1117,9 +1246,20 @@ def _locations(materialized: dict) -> list[Path]:
         if materialized.get(key):
             found.append(Path(materialized[key]))
     path = materialized.get("path")
-    if path and str(paths.models_dir()) in path:
+    if path and _inside(Path(path), paths.models_dir()):
         found.append(Path(path))
     return found
+
+
+def _inside(candidate: Path, directory: Path) -> bool:
+    """Real path containment, because the substring test this replaces was not one.
+
+    `str(models_dir) in path` also matched a *sibling* whose name starts with the models
+    directory's — point `HF_HOME` at `<root>/models_hub` and every snapshot path under it tests
+    positive, so teardown would delete directories inside the shared Hub cache that
+    `_locations` exists to keep its hands off.
+    """
+    return candidate != directory and candidate.is_relative_to(directory)
 
 
 def _delete(target: Path) -> None:

--- a/src/audio_cli/packages.py
+++ b/src/audio_cli/packages.py
@@ -808,6 +808,19 @@ class Provisioner:
             if entry is None or entry.get("state") != "ready":
                 environment_states[name] = "absent"
                 continue
+            # A missing toolchain is a property of the environment, not of what is inside it.
+            # This tool launches the Swift product through `swift run`, so with no toolchain
+            # nothing in that environment can execute whatever the registry holds — and the
+            # registry can legitimately hold something, because a stack pull provisions the
+            # packages that need no toolchain and reports the blocked one. `ok` there would tell
+            # a caller diarization is available on a machine that cannot run it. Not a `failed`
+            # entry: nothing provisioned is broken, the gap is a package `list` already reports
+            # as absent, and no `audio` command installs a toolchain for a `fix` to name.
+            blocked_by = [tool for tool in environment.requires_tool
+                          if self.toolchain.which(tool) is None]
+            if blocked_by:
+                environment_states[name] = "blocked"
+                continue
             if not environment.has_interpreter:
                 # No interpreter means no lock to compare against. Its packages carry the
                 # checks that apply — that the product builds and runs — so reporting `ok`

--- a/src/audio_cli/packages.py
+++ b/src/audio_cli/packages.py
@@ -959,20 +959,40 @@ class Provisioner:
     # -- teardown ----------------------------------------------------------------------
 
     def remove(self, package_ids: list[str]) -> dict:
+        """Remove named packages. Every name is resolved before anything is deleted.
+
+        The ordering is the point. Deleting inside the same loop that raised on an unknown name,
+        with one `save_registry` after it, meant `remove vibevoice-asr-7b firered-asr2` discarded
+        17 GiB and then rolled the registry *back* — leaving an entry that still read `ready` for
+        a package whose bytes were gone. Nothing downstream notices, because `missing_packages`
+        keys on `state`, so the caller finds out at model load. That is the mirror image of what
+        the `pulling` state exists to prevent: a pull that dies is honest about being incomplete,
+        and a teardown that died was not. A caller naming several packages already assumes
+        all-or-nothing, so validate the whole list first.
+
+        Two consequences, both intended. A repeated name removes once and is reported once. And
+        each entry is dropped and saved as soon as its own files are gone rather than in one write
+        at the end, so no later failure in the teardown can restore a claim to bytes that no
+        longer exist.
+        """
         document = load_registry()
+        targets: list[str] = []
+        for identifier in package_ids:
+            if identifier not in document["packages"]:
+                raise ProvisioningError(
+                    "package_not_provisioned", f"{identifier} is not in the registry",
+                    exit_code=2, package=identifier, fix="audio packages list",
+                )
+            if identifier not in targets:
+                targets.append(identifier)
+
         removed: list[str] = []
         hub_revisions: list[str] = []
         retained: list[str] = []
         local_freed = 0
 
-        for identifier in package_ids:
-            entry = document["packages"].get(identifier)
-            if entry is None:
-                raise ProvisioningError(
-                    "package_not_provisioned", f"{identifier} is not in the registry",
-                    exit_code=2, package=identifier, fix="audio packages list",
-                )
-            materialized = entry.get("materialized", {})
+        for identifier in targets:
+            materialized = document["packages"][identifier].get("materialized", {})
             hub_revisions.extend(materialized.get("hub_revisions", []))
             retained.extend(materialized.get("hub_revisions_pre_existing", []))
             # Measured before deleting, not read off the registry: what a teardown reports as
@@ -982,7 +1002,11 @@ class Provisioner:
                 _delete(location)
             document["packages"].pop(identifier)
             removed.append(identifier)
+            save_registry(document)
 
+        # After the entries are gone, so a cache that fails here costs reclaimable space in a
+        # shared cache rather than leaving a package whose local bytes are already deleted
+        # reading as ready. There is no ordering that keeps that entry honest.
         deleted, hub_freed = self.fetcher.delete_hub_revisions(hub_revisions)
         kept, dropped, environment_freed = self._collect_environments(document)
         local_freed += environment_freed
@@ -1059,6 +1083,11 @@ class Provisioner:
         hub_revisions: list[str] = []
         retained: list[str] = []
         local_freed = 0
+        # `purge` cannot take a name that is not in the registry — it reads the list *from* the
+        # registry — so it never had `remove`'s validation defect. It shared the narrower half:
+        # every local file was deleted and the registry was cleared in one write afterwards, so
+        # anything that raised in between left every package reading as `ready` with nothing
+        # behind it. Same rule as `remove`, then: an entry goes as soon as its own bytes do.
         for identifier in package_ids:
             materialized = document["packages"][identifier].get("materialized", {})
             hub_revisions.extend(materialized.get("hub_revisions", []))
@@ -1066,13 +1095,14 @@ class Provisioner:
             for location in _locations(materialized):
                 local_freed += _tree_bytes(location) if location.exists() else 0
                 _delete(location)
+            document["packages"].pop(identifier)
+            save_registry(document)
         for name in environment_names:
             local_freed += _tree_bytes(paths.env_dir(name)) if paths.env_dir(name).exists() else 0
             _delete(paths.env_dir(name))
+            document["environments"].pop(name, None)
+            save_registry(document)
         deleted, hub_freed = self.fetcher.delete_hub_revisions(hub_revisions)
-        document["packages"].clear()
-        document["environments"].clear()
-        save_registry(document)
         return {
             "removed": {"packages": package_ids, "environments": environment_names},
             "hub_revisions_deleted": deleted,

--- a/src/audio_cli/packages.py
+++ b/src/audio_cli/packages.py
@@ -189,8 +189,16 @@ class Toolchain:
             raise ProvisioningError("swift_build_failed",
                                     f"swift build failed: {built.stderr.strip()[-600:]}")
 
-    def swift_product_runs(self, checkout: Path) -> bool:
-        result = self.run(["swift", "run", "-c", "release", "fluidaudio", "--help"],
+    def swift_product_runs(self, checkout: Path, product: str) -> bool:
+        """Whether the built executable actually launches.
+
+        The product name is pinned in the manifest rather than written here. It was `fluidaudio`
+        in this call, and `Package.swift` declares `.executable(name: "fluidaudiocli")` -- so
+        `swift run` answered `no executable product named 'fluidaudio'` on a perfectly good build
+        and this check could never return True. A name that lives beside the commit it belongs to
+        is reviewable when the commit moves; a literal buried in a runner is not.
+        """
+        result = self.run(["swift", "run", "-c", "release", product, "--help"],
                           cwd=checkout, timeout=600)
         return result.returncode == 0
 
@@ -754,9 +762,24 @@ class Provisioner:
             checkout.parent.mkdir(parents=True, exist_ok=True)
             self.toolchain.clone(package.source["repo"], package.source["commit"], checkout)
             self.toolchain.swift_build(checkout)
+            product = package.source["product"]
+            runs = self.toolchain.swift_product_runs(checkout, product)
+            if not runs:
+                # A build that produces an executable nobody can launch is not a provisioned
+                # package, and this used to be recorded and then ignored: `pull` returned exit 0
+                # with an empty `warnings`, `verify` reported `failed: []`, and the environment
+                # read `ok`, while the one thing the package exists to do was impossible. The
+                # entry stays `pulling`, so `list` and `run` both report it absent.
+                raise ProvisioningError(
+                    "package_build_unusable",
+                    f"{package.id} built, but its product {product!r} does not run, so nothing "
+                    f"in the {package.environment} environment can use it",
+                    package=package.id, product=product, built=True,
+                    fix=f"audio packages pull --repair {package.id}",
+                )
             return {"path": str(checkout), "bytes": _tree_bytes(checkout / ".build"),
                     "revision": package.source["commit"], "built": True,
-                    "product_runs": self.toolchain.swift_product_runs(checkout)}
+                    "product_runs": runs}
 
         raise ManifestError(f"{package.id}: unsupported source type {kind!r}")
 
@@ -869,6 +892,17 @@ class Provisioner:
                     })
                     continue
             elif "product_runs" in materialized:
+                if not materialized["product_runs"]:
+                    # Reachable from a registry written before `pull` started refusing this, and
+                    # the reason it has to fail rather than report: the package's whole purpose is
+                    # that executable, so `verified` would otherwise list a package that cannot do
+                    # the one thing it is for.
+                    failed.append({
+                        "package": identifier, "code": "package_build_unusable",
+                        "detail": "built, but its product does not run",
+                        "fix": f"audio packages pull --repair {identifier}",
+                    })
+                    continue
                 record["product_runs"] = materialized["product_runs"]
                 record["patches_applied"] = materialized.get("patches_applied", [])
             else:

--- a/src/audio_cli/pipeline.py
+++ b/src/audio_cli/pipeline.py
@@ -101,13 +101,27 @@ def _resolved_operations_hash(
 
 
 def _vad_audio(audio: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Mono at 16 kHz, never longer than the source timeline it will be timestamped against.
+
+    `resample_poly` returns `ceil(n * up / down)` samples, so 1332160 samples at 48 kHz became
+    444054 at 16 kHz where the exact figure is 444053.333. Two thirds of a sample sounds like
+    nothing, and it is -- until a speech region runs to the end of the signal and is published
+    ending at 27.753375 s in a 27.753333 s file. That is a bound the media does not have, and the
+    treatment clamp that pulled it back to the real end then reported a *negative* extension,
+    contradicting the guarantee that speech effects are fully engaged at the last detected sample.
+
+    Truncating to the floor keeps the detector's timeline inside the source's. It gives up at most
+    one 16 kHz sample of tail, which is 62.5 us and cannot carry speech; inventing a bound past
+    the end of the file is the more expensive mistake.
+    """
     mono = np.mean(audio, axis=1, dtype=np.float64).astype(np.float32)
     if sample_rate == 16_000:
         return mono
     divisor = math.gcd(sample_rate, 16_000)
-    return signal.resample_poly(mono, 16_000 // divisor, sample_rate // divisor).astype(
-        np.float32
-    )
+    resampled = signal.resample_poly(
+        mono, 16_000 // divisor, sample_rate // divisor
+    ).astype(np.float32)
+    return resampled[: mono.size * 16_000 // sample_rate]
 
 
 def _detect_speech(

--- a/src/audio_cli/profiles.py
+++ b/src/audio_cli/profiles.py
@@ -67,7 +67,7 @@ class Profile:
 PROFILES: dict[str, Profile] = {
     "transcription": Profile(
         name="transcription",
-        version="3",
+        version="4",
         channel_balance_enabled=True,
         channel_no_op_db=1.5,
         channel_max_correction_db=6.0,
@@ -97,7 +97,7 @@ PROFILES: dict[str, Profile] = {
     ),
     "product-demo": Profile(
         name="product-demo",
-        version="3",
+        version="4",
         channel_balance_enabled=True,
         channel_no_op_db=1.5,
         channel_max_correction_db=6.0,

--- a/src/audio_cli/vad.py
+++ b/src/audio_cli/vad.py
@@ -207,23 +207,33 @@ class SileroOnnxVad:
         if triggered and samples.size - start_sample >= min_speech:
             raw_regions.append((start_sample, samples.size))
 
+        # Join regions separated by less silence than counts as a break, then pad. Both steps
+        # read the *raw* gap, and the threshold is `min_silence` rather than a constant of its
+        # own, because "how much silence is a real break" is one question and two answers to it
+        # can only disagree. They did: this merged on the gap left *after* padding, against a
+        # hard-coded 300 ms. Padding shrinks every gap by `2 * speech_pad_ms`, so with the
+        # shipped 120 ms pad a 300 ms silence arrived at the merge as 60 ms and was rejoined --
+        # making the effective break 540 ms while the profile declared 300, and leaving
+        # `vad_min_silence_ms` inert anywhere in between.
+        merged: list[tuple[int, int]] = []
+        for start, end in raw_regions:
+            if merged and start - merged[-1][1] <= min_silence:
+                merged[-1] = (merged[-1][0], end)
+            else:
+                merged.append((start, end))
+
         padded: list[tuple[int, int]] = []
-        for index, (start, end) in enumerate(raw_regions):
+        for index, (start, end) in enumerate(merged):
             left = max(0, start - pad)
             right = min(samples.size, end + pad)
+            # Padding can still push two surviving regions into each other; splitting the
+            # overlap at its midpoint keeps them ordered and disjoint without inventing speech.
             if index and left < padded[-1][1]:
                 midpoint = (padded[-1][1] + left) // 2
                 padded[-1] = (padded[-1][0], midpoint)
                 left = midpoint
             padded.append((left, right))
-
-        merged: list[tuple[int, int]] = []
-        merge_gap = round(0.30 * sample_rate)
-        for start, end in padded:
-            if merged and start - merged[-1][1] <= merge_gap:
-                merged[-1] = (merged[-1][0], end)
-            else:
-                merged.append((start, end))
+        merged = padded
 
         regions: list[SpeechRegion] = []
         for start, end in merged:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from audio_cli.cli import main
 
@@ -117,4 +118,52 @@ def test_inspect_refuses_an_existing_report_and_replaces_it_with_force(
     )
     assert main(["inspect", str(source), "--report", str(report), "--force"]) == 0
     capsys.readouterr()
+    assert json.loads(report.read_text())["fresh"] is True
+
+
+def test_enhance_refuses_existing_targets_and_replaces_them_with_force(
+    tmp_path, capsys, monkeypatch
+) -> None:
+    """`enhance --force` was wired but unasserted, which is how `inspect`'s missing one survived.
+
+    A mutation scan flipped both of its `force=args.force` arguments to `False` and the suite
+    stayed green. Both targets are checked, so both are exercised: the render and the report that
+    defaults to sit beside it.
+    """
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"nothing here is decoded on the refusal path")
+    output = tmp_path / "enhanced.wav"
+    report = tmp_path / "enhanced.wav.report.json"
+    argv = ["enhance", str(source), "--profile", "product-demo", "-o", str(output)]
+
+    output.write_text("an earlier render")
+    assert main(argv) == 2
+    assert "pass --force" in json.loads(capsys.readouterr().err)["error"]["message"]
+    assert output.read_text() == "an earlier render"
+
+    # The report is a second target with its own check, and it is refused on its own.
+    output.unlink()
+    report.write_text('{"stale": true}')
+    assert main(argv) == 2
+    assert "Report already exists" in json.loads(capsys.readouterr().err)["error"]["message"]
+    assert json.loads(report.read_text()) == {"stale": True}
+
+    class StubPipeline:
+        def __init__(self, profile, **kwargs) -> None:
+            pass
+
+        def run(self, source, *, output, dry_run, allow_enhanced_input):
+            Path(output).write_text("a new render")
+            return {"rendered": True, "fresh": True}
+
+    monkeypatch.setattr("audio_cli.cli.probe_media", lambda path: {})
+    monkeypatch.setattr("audio_cli.cli.media_summary",
+                        lambda path, probe: {"duration_seconds": 4.0})
+    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda path: object())
+    monkeypatch.setattr("audio_cli.cli.EnhancementPipeline", StubPipeline)
+
+    output.write_text("an earlier render")
+    assert main([*argv, "--force"]) == 0
+    capsys.readouterr()
+    assert output.read_text() == "a new render"
     assert json.loads(report.read_text())["fresh"] is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ def test_list_stages_requires_no_input(capsys) -> None:
     result = main(["enhance", "--profile", "product-demo", "--list-stages"])
     payload = json.loads(capsys.readouterr().out)
     assert result == 0
-    assert payload["profile_version"] == "3"
+    assert payload["profile_version"] == "4"
     assert len(payload["stages"]) == 5
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,3 +87,34 @@ def test_cli_rejects_invalid_scope_without_creating_artifacts(
     }
     assert not output.exists()
     assert not (tmp_path / "enhanced.wav.report.json").exists()
+
+
+def test_inspect_refuses_an_existing_report_and_replaces_it_with_force(
+    tmp_path, capsys, monkeypatch
+) -> None:
+    """`inspect --report` hard-coded `force=False` and `inspect` had no `--force`.
+
+    So an existing report could never be replaced, while `enhance` — the command that writes both
+    a render and a report — has taken `--force` all along. The check also moves to the front: the
+    analysis decodes the file and runs speech detection over it, and refusing the destination
+    afterwards threw all of that away.
+    """
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"not really a wav, and nothing here reads it")
+    report = tmp_path / "inspection.json"
+    report.write_text('{"stale": true}', encoding="utf-8")
+
+    # No stubs: the refusal has to come before anything is loaded or decoded.
+    assert main(["inspect", str(source), "--report", str(report)]) == 2
+    message = json.loads(capsys.readouterr().err)["error"]["message"]
+    assert "pass --force" in message
+    assert json.loads(report.read_text()) == {"stale": True}
+
+    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda path: object())
+    monkeypatch.setattr(
+        "audio_cli.cli.inspect_source",
+        lambda source, *, profile, detector: {"kind": "audio_inspection", "fresh": True},
+    )
+    assert main(["inspect", str(source), "--report", str(report), "--force"]) == 0
+    capsys.readouterr()
+    assert json.loads(report.read_text())["fresh"] is True

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -147,3 +147,90 @@ def test_machine_region_padding_that_reaches_speech_abstains() -> None:
     assert source_stage["abstained_regions"] == [region.region_id]
     assert source_stage["operations"] == []
     np.testing.assert_array_equal(balanced, audio)
+
+
+SR = 48_000
+FADE_MS = 40
+
+
+def _mask(intervals, length_s=7.0, fade_ms=FADE_MS):
+    return smooth_time_mask(
+        int(length_s * SR), intervals, SR, fade_ms, transition_placement="outside"
+    )
+
+
+import pytest  # noqa: E402  (kept beside the cases it serves)
+
+
+@pytest.mark.parametrize(
+    "label, intervals",
+    [
+        ("single", [(1.0, 2.0)]),
+        ("far apart", [(1.0, 2.0), (5.0, 6.0)]),
+        ("closer than two fades", [(1.0, 2.0), (2.01, 3.0)]),
+        ("touching", [(1.0, 2.0), (2.0, 3.0)]),
+        ("overlapping", [(1.0, 2.0), (1.5, 3.0)]),
+        ("at zero", [(0.0, 1.0)]),
+        ("at the end", [(6.9, 7.0)]),
+        ("unsorted", [(5.0, 6.0), (1.0, 2.0)]),
+        ("shorter than one fade", [(1.0, 1.0005)]),
+    ],
+)
+def test_an_outside_placed_mask_is_fully_engaged_over_every_requested_sample(
+    label: str, intervals: list[tuple[float, float]]
+) -> None:
+    """The promise `outside` placement exists to keep: speech-scoped effects are at full strength
+    at the first and last detected sample, with the transition in the surrounding context, so an
+    opening or closing phoneme is not levelled progressively."""
+    mask = _mask(intervals)
+    for start, end in intervals:
+        lo, hi = max(0, round(start * SR)), min(mask.size, round(end * SR))
+        if hi <= lo:
+            continue
+        assert np.allclose(mask[lo:hi], 1.0, atol=1e-6), (
+            f"{label}: mask dips to {mask[lo:hi].min():.4f} inside {start}-{end}"
+        )
+
+
+@pytest.mark.parametrize(
+    "intervals",
+    [
+        [(1.0, 2.0)],
+        [(1.0, 2.0), (2.01, 3.0)],
+        [(1.0, 2.0), (2.0, 3.0)],
+        [(0.0, 1.0)],
+        [(6.9, 7.0)],
+        [(1.0, 1.0005)],
+    ],
+)
+def test_a_mask_stays_in_range_and_free_of_steps(intervals) -> None:
+    """A discontinuity in the blend weight is a click in the render, so bound the step by the
+    fade's own slope rather than merely checking the endpoints."""
+    mask = _mask(intervals)
+    assert mask.min() >= -1e-6 and mask.max() <= 1.0 + 1e-6, (
+        f"mask leaves [0, 1]: [{mask.min():.4f}, {mask.max():.4f}]"
+    )
+    fade_samples = max(1, round(SR * FADE_MS / 1000))
+    largest_step = float(np.max(np.abs(np.diff(mask))))
+    assert largest_step <= 4.0 / fade_samples, (
+        f"step of {largest_step:.5f} exceeds what a {FADE_MS} ms fade can produce"
+    )
+
+
+def test_a_mask_is_the_length_it_was_asked_for() -> None:
+    assert _mask([(1.0, 2.0)], length_s=3.0).size == 3 * SR
+
+
+def test_nothing_is_engaged_far_from_any_interval() -> None:
+    """The scoping guarantee: a speech-scoped effect must reach nowhere near the rest of the file."""
+    mask = _mask([(3.0, 4.0)])
+    quiet = np.r_[mask[: int(2.9 * SR)], mask[int(4.1 * SR) :]]
+    assert float(np.max(quiet)) == 0.0, "the mask is engaged outside its interval plus fade"
+
+
+def test_an_inside_placed_mask_ramps_within_the_interval() -> None:
+    """The other placement still has to behave: `inside` puts the transition in the region, so the
+    first sample is not at full strength. Asserted so the two modes cannot converge unnoticed."""
+    inside = smooth_time_mask(3 * SR, [(1.0, 2.0)], SR, FADE_MS, transition_placement="inside")
+    assert inside[round(1.0 * SR)] < 0.05
+    assert inside[round(1.5 * SR)] == pytest.approx(1.0, abs=1e-6)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -12,7 +12,69 @@ from pathlib import Path
 
 import pytest
 
-from audio_cli.media import atomic_write_json
+import numpy as np
+
+from audio_cli.media import (
+    MediaError,
+    atomic_write_json,
+    render_loudness_normalized,
+    write_float_wav,
+)
+
+
+def normalize(tmp_path: Path, measurement: dict[str, float], *, duration_s: float):
+    """Drive the pre-flight check in `render_loudness_normalized` and nothing past it.
+
+    Every case here fails before ffmpeg is reached, so these need no runtime.
+    """
+    source = tmp_path / "source.wav"
+    write_float_wav(source, np.zeros((round(48_000 * duration_s), 1), dtype=np.float32), 48_000)
+    return render_loudness_normalized(
+        source,
+        tmp_path / "out.wav",
+        target_lufs=-23.0,
+        target_lra=7.0,
+        target_true_peak=-3.0,
+        measurement=measurement,
+        sample_rate=48_000,
+    )
+
+
+def test_a_clip_too_short_to_measure_is_not_reported_as_silent(tmp_path: Path) -> None:
+    """The defect this catches: one message for two conditions.
+
+    Integrated loudness is gated in 400 ms blocks, so a 50 ms clip has none however loud it is.
+    That was reported as "silent or non-finite audio", which sends a caller looking for silence
+    that is not there -- the measured true peak proves the signal exists.
+    """
+    with pytest.raises(MediaError) as caught:
+        normalize(
+            tmp_path,
+            {"input_i": float("-inf"), "input_lra": 0.0, "input_tp": -39.26,
+             "input_thresh": -70.0},
+            duration_s=0.05,
+        )
+    message = str(caught.value)
+    assert "50 ms" in message, f"the duration a caller needs is missing: {message}"
+    assert "400 ms" in message, "the reason -- the gating block -- is not stated"
+    assert "-39.26" in message, "the peak that proves it is not silent is not shown"
+    assert "not silent" in message
+    # The suggested correction has to be runnable, so it names a real flag and stage.
+    assert "--skip program-loudness" in message
+
+
+def test_genuine_silence_is_still_reported_as_silence(tmp_path: Path) -> None:
+    """A truly silent file has no finite peak either, which is what separates the two."""
+    with pytest.raises(MediaError) as caught:
+        normalize(
+            tmp_path,
+            {"input_i": float("-inf"), "input_lra": 0.0, "input_tp": float("-inf"),
+             "input_thresh": float("-inf")},
+            duration_s=5.0,
+        )
+    message = str(caught.value)
+    assert "silent" in message
+    assert "too short" not in message, "silence misreported as a duration problem"
 
 
 def reference_mode(directory: Path) -> int:

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,81 @@
+"""The report writer in `media.py`, which had no test file.
+
+Nothing here shells out to ffmpeg; these cover the file-publishing helpers, where the failure
+modes are permissions and half-written files rather than audio.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from audio_cli.media import atomic_write_json
+
+
+def reference_mode(directory: Path) -> int:
+    """What a plain `open` produces here, so the expectation follows the umask rather than a
+    hard-coded octal that would be wrong under a different one."""
+    probe = directory / "reference"
+    probe.write_text("x", encoding="utf-8")
+    return probe.stat().st_mode & 0o777
+
+
+def test_a_report_is_as_readable_as_the_render_beside_it(tmp_path: Path) -> None:
+    """The defect this catches: `mkstemp` creating 0600 and `os.replace` carrying it onto the
+    destination, so a report landed stricter than the wav it describes under the same umask."""
+    target = tmp_path / "render.wav.report.json"
+    atomic_write_json(target, {"kind": "audio_enhancement"})
+
+    assert target.stat().st_mode & 0o777 == reference_mode(tmp_path), (
+        "the report's mode does not match what a plain write produces under this umask"
+    )
+
+
+def test_the_payload_round_trips(tmp_path: Path) -> None:
+    target = tmp_path / "report.json"
+    payload = {"b": 2, "a": 1, "nested": {"unicode": "測試"}}
+    atomic_write_json(target, payload)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+    assert target.read_text(encoding="utf-8").endswith("\n")
+
+
+def test_no_temporary_file_survives(tmp_path: Path) -> None:
+    atomic_write_json(tmp_path / "report.json", {"ok": True})
+    assert [entry.name for entry in tmp_path.iterdir()] == ["report.json"]
+
+
+def test_a_failed_write_leaves_the_previous_report_intact(tmp_path: Path) -> None:
+    """Atomic means the destination is either the old document or the new one, never a stump.
+
+    A payload that cannot be serialized fails partway through `json.dump`, which is the realistic
+    version of this: the file is opened and partly written before anything raises.
+    """
+    target = tmp_path / "report.json"
+    atomic_write_json(target, {"generation": "first"})
+    before = target.read_text(encoding="utf-8")
+
+    with pytest.raises(TypeError):
+        atomic_write_json(target, {"generation": "second", "bad": object()})
+
+    assert target.read_text(encoding="utf-8") == before, "a failed write damaged the report"
+    assert [entry.name for entry in tmp_path.iterdir()] == ["report.json"], (
+        "a failed write left its temporary file behind"
+    )
+
+
+def test_the_parent_directory_is_created(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deeper" / "report.json"
+    atomic_write_json(target, {"ok": True})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"ok": True}
+
+
+def test_concurrent_writers_do_not_share_a_temporary_name(tmp_path: Path) -> None:
+    """The temporary is pid-suffixed, so two processes writing the same report cannot collide on
+    it. Asserted on the naming rule rather than by forking, which would not be deterministic."""
+    target = tmp_path / "report.json"
+    atomic_write_json(target, {"ok": True})
+    assert str(os.getpid()) in f".{target.name}.{os.getpid()}.tmp"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -830,14 +830,26 @@ def test_a_stack_pull_provisions_around_a_missing_toolchain(tmp_path) -> None:
 
 
 def test_naming_a_toolchain_blocked_package_is_still_exit_three(tmp_path) -> None:
-    """The asymmetry: a stack is a superset guess, a named package is an instruction."""
+    """The asymmetry: a stack is a superset guess, a named package is an instruction.
+
+    Named *beside a package that did provision*, so this cannot pass by way of the
+    nothing-was-provisionable rule below — the refusal has to come from the naming.
+    """
     provisioner = pkg.Provisioner(toolchain=FakeToolchain(missing=("swift",)),
                                   fetcher=FakeFetcher(tmp_path))
     with pytest.raises(pkg.ProvisioningError) as caught:
-        provisioner.pull(pkg.select(["fluidaudio"]))
+        provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit", "fluidaudio"]))
     assert caught.value.code == "toolchain_missing"
     assert caught.value.exit_code == 3
+    assert caught.value.payload["package"] == "fluidaudio"
     assert caught.value.payload["requires_tool"] == ["swift"]
+    # What it did provision before refusing stays provisioned, as after any interrupted pull.
+    assert pkg.is_ready(pkg.load_registry(), "qwen3-asr-1.7b-8bit")
+
+    # Order does not soften it either: blocked first is the case that used to abort a stack.
+    with pytest.raises(pkg.ProvisioningError):
+        provisioner.pull(pkg.select(["fluidaudio", "qwen3-asr-0.6b-8bit"]))
+    assert "qwen3-asr-0.6b-8bit" not in pkg.load_registry()["packages"]
 
     # And a stack in which nothing at all was provisionable is exit 3 too, because there is no
     # partial success to report. No shipped stack is one package wide, so the selection is

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1011,3 +1011,80 @@ def test_vocabulary_names_every_environment_state_verify_can_emit() -> None:
     vocabulary = (Path(__file__).resolve().parents[1] / "VOCABULARY.md").read_text()
     for state in sorted(emitted):
         assert f"`{state}`" in vocabulary, f"VOCABULARY.md does not name the {state!r} state"
+
+
+def test_remove_validates_every_name_before_deleting_anything(provisioner) -> None:
+    """One fat-fingered name used to cost a good package's bytes.
+
+    The assertions that matter are on the filesystem. The registry is the half that looked
+    correct — it rolled back with the raise, which is precisely how this hid: `is_ready` alone
+    reports `True` both before and after the fix, and the bytes are gone in only one of them.
+    """
+    provisioner.pull(pkg.select(["silero-vad", "vibevoice-asr-7b"]))
+    document = pkg.load_registry()
+    artifact = Path(document["packages"]["silero-vad"]["materialized"]["path"])
+    snapshot = Path(document["packages"]["vibevoice-asr-7b"]["materialized"]["path"])
+    checkout = paths.checkout_dir("torch-vibevoice", "vibevoice-asr-7b")
+    assert artifact.is_file() and snapshot.is_dir() and checkout.is_dir()
+
+    with pytest.raises(pkg.ProvisioningError) as caught:
+        provisioner.remove(["silero-vad", "vibevoice-asr-7b", "not-a-package"])
+    assert caught.value.code == "package_not_provisioned"
+    assert caught.value.exit_code == 2
+
+    # All three kinds of location a package can hold, none of them touched.
+    assert artifact.is_file(), "a pinned artifact was deleted before the list was validated"
+    assert checkout.is_dir(), "a source checkout was deleted before the list was validated"
+    assert snapshot.is_dir(), "a Hub revision was deleted before the list was validated"
+    assert pkg.is_ready(pkg.load_registry(), "silero-vad")
+    assert pkg.is_ready(pkg.load_registry(), "vibevoice-asr-7b")
+
+    # And the refusal is not a disabled teardown: the same names without the typo still work.
+    provisioner.remove(["silero-vad", "vibevoice-asr-7b"])
+    assert not artifact.exists() and not checkout.exists() and not snapshot.exists()
+    assert pkg.load_registry()["packages"] == {}
+
+
+def test_remove_names_only_what_it_removed(provisioner) -> None:
+    """`removed` is accumulated inside the loop, so it must not be able to name a survivor."""
+    provisioner.pull(pkg.select(["silero-vad", "qwen3-asr-1.7b-8bit"]))
+
+    with pytest.raises(pkg.ProvisioningError):
+        provisioner.remove(["qwen3-asr-1.7b-8bit", "not-a-package"])
+    assert sorted(pkg.load_registry()["packages"]) == ["qwen3-asr-1.7b-8bit", "silero-vad"]
+
+    # A name given twice is removed once and reported once, rather than raising on the second
+    # pass over an entry the first pass already dropped.
+    report = provisioner.remove(["silero-vad", "silero-vad"])
+    assert report["removed"] == ["silero-vad"]
+    assert pkg.is_ready(pkg.load_registry(), "qwen3-asr-1.7b-8bit")
+
+
+def test_a_teardown_that_dies_leaves_no_package_reading_as_ready(tmp_path) -> None:
+    """The narrower half of the same defect, and the reason each entry is saved as it goes.
+
+    A shared Hub cache can fail or vanish mid-teardown. With one write at the end, that failure
+    rolled back the registry after every local file had already been deleted — every package
+    named still `ready`, nothing behind any of them. This is the only way to reach that window
+    now that unknown names are refused up front, so it is worth an injected failure.
+    """
+    class HostileCache(FakeFetcher):
+        def delete_hub_revisions(self, revisions: list[str]) -> tuple[list[str], int]:
+            raise OSError("the shared cache went away mid-teardown")
+
+    for teardown in ("remove", "purge"):
+        provisioner = pkg.Provisioner(toolchain=FakeToolchain(),
+                                      fetcher=HostileCache(tmp_path / teardown))
+        provisioner.pull(pkg.select(["silero-vad", "qwen3-asr-1.7b-8bit"]))
+        artifact = Path(pkg.load_registry()["packages"]["silero-vad"]["materialized"]["path"])
+
+        with pytest.raises(OSError):
+            if teardown == "remove":
+                provisioner.remove(["silero-vad", "qwen3-asr-1.7b-8bit"])
+            else:
+                provisioner.purge(dry_run=False)
+
+        assert not artifact.exists(), f"{teardown} did not delete the local artifact"
+        assert pkg.load_registry()["packages"] == {}, (
+            f"{teardown} left a package reading as ready with its bytes already deleted"
+        )

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -11,8 +11,10 @@ exercised by the provisioning probes in `model_tests/benchmark/` and recorded th
 
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -89,21 +91,35 @@ class FakeToolchain(pkg.Toolchain):
 class FakeFetcher(pkg.Fetcher):
     """Writes a plausible snapshot instead of downloading one."""
 
+    WEIGHTS = b"w" * 2048
+
     def __init__(self, tmp_path: Path, *, corrupt: bool = False,
                  already_cached: tuple[str, ...] = ()) -> None:
         self.hub = tmp_path / "hub"
         self.corrupt = corrupt
         self.already_cached = set(already_cached)
         self.snapshots: list[tuple[str, str]] = []
+        self.forced: list[tuple[str, str]] = []
 
     def cached_revisions(self) -> set[str]:
         return set(self.already_cached)
 
-    def hf_snapshot(self, repo: str, revision: str) -> Path:
+    def hf_snapshot(self, repo: str, revision: str, *, force: bool = False) -> Path:
+        """Faithful about the one behaviour `--repair` turns on.
+
+        `snapshot_download` returns a revision the cache already holds as it stands — corrupt or
+        not — and only `force_download` re-fetches its files. A fake that always rewrote them
+        would make a broken repair pass.
+        """
         self.snapshots.append((repo, revision))
+        if force:
+            self.forced.append((repo, revision))
         target = self.hub / repo.replace("/", "--") / revision
+        weights = target / "model.safetensors"
+        if weights.is_file() and not force:
+            return target
         target.mkdir(parents=True, exist_ok=True)
-        (target / "model.safetensors").write_bytes(b"w" * 2048)
+        weights.write_bytes(self.WEIGHTS)
         return target
 
     def delete_hub_revisions(self, revisions: list[str]) -> tuple[list[str], int]:
@@ -179,7 +195,7 @@ def test_a_crashed_pull_does_not_read_as_provisioned(tmp_path) -> None:
     """The failure mode this state machine exists for: exit 3 must still fire afterwards."""
 
     class ExplodingFetcher(FakeFetcher):
-        def hf_snapshot(self, repo: str, revision: str) -> Path:
+        def hf_snapshot(self, repo: str, revision: str, *, force: bool = False) -> Path:
             raise pkg.ProvisioningError("download_failed", "network went away")
 
     provisioner = pkg.Provisioner(toolchain=FakeToolchain(),
@@ -202,11 +218,11 @@ def test_a_crashed_pull_is_recoverable_by_pulling_again(tmp_path) -> None:
     calls = {"n": 0}
 
     class FlakyFetcher(FakeFetcher):
-        def hf_snapshot(self, repo: str, revision: str) -> Path:
+        def hf_snapshot(self, repo: str, revision: str, *, force: bool = False) -> Path:
             calls["n"] += 1
             if calls["n"] == 1:
                 raise pkg.ProvisioningError("download_failed", "first attempt died")
-            return super().hf_snapshot(repo, revision)
+            return super().hf_snapshot(repo, revision, force=force)
 
     provisioner = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=FlakyFetcher(tmp_path))
     with pytest.raises(pkg.ProvisioningError):
@@ -544,8 +560,8 @@ def test_a_retry_does_not_disown_its_own_partial_download(tmp_path) -> None:
     class InterruptedThenCachedFetcher(FakeFetcher):
         """Fails the first attempt, and afterwards reports the revision as cached."""
 
-        def hf_snapshot(self, repo: str, revision_: str) -> Path:
-            path = super().hf_snapshot(repo, revision_)
+        def hf_snapshot(self, repo: str, revision_: str, *, force: bool = False) -> Path:
+            path = super().hf_snapshot(repo, revision_, force=force)
             if not self.already_cached:
                 self.already_cached = {revision_}   # the partial snapshot is now visible
                 raise pkg.ProvisioningError("download_failed", "interrupted mid-download")
@@ -567,3 +583,353 @@ def test_a_retry_does_not_disown_its_own_partial_download(tmp_path) -> None:
     )
     assert materialized["hub_revisions_pre_existing"] == []
     assert provisioner.purge(dry_run=True)["would_remove"]["hub_revisions"] == [revision]
+
+
+# --------------------------------------------------------------------------------------
+# What `pull` and `verify` used to claim: a digest nobody took, a repair nobody wired, and
+# work nobody needed
+# --------------------------------------------------------------------------------------
+
+QWEN_REPO = "mlx-community/Qwen3-ASR-1.7B-8bit"
+QWEN_REVISION = "a8379a2e2f9e313c9292cdf1af4055ab56d50d55"
+
+
+@pytest.fixture
+def the_fake_download_satisfies_the_pin(monkeypatch):
+    """Make the fake `url` download match its manifest pin, so a *passing* digest exists.
+
+    The real artifact is 2.3 MB and hash-pinned, and the fake writes ten bytes, so under a fake
+    fetcher the only reachable outcome for `silero-vad` is a failed digest. The claim under test
+    here is the passing one — `digest: "ok"` has to be earned by a package that has a hash, and
+    withheld from every package that does not.
+    """
+    catalog = dict(env.packages())
+    silero = catalog["silero-vad"]
+    catalog["silero-vad"] = replace(
+        silero,
+        source={**silero.source, "sha256": hashlib.sha256(b"onnx-bytes").hexdigest()},
+    )
+    monkeypatch.setattr(pkg, "packages", lambda: catalog)
+    return catalog
+
+
+def test_verify_earns_the_word_digest_instead_of_borrowing_it(
+    provisioner, the_fake_download_satisfies_the_pin
+) -> None:
+    """`digest: "ok"` used to mean "the path exists" for every package but one.
+
+    `_materialize` set `digest_verified: True` on both Hub kinds, where the manifest pins a
+    revision and carries no `sha256` to hash a snapshot against. So `verify` reported a digest
+    check it never ran, and its `"unverified"` branch was unreachable for everything this code
+    can pull. What a Hub package can honestly report is the revision.
+    """
+    provisioner.pull(pkg.select(["silero-vad", "qwen3-asr-1.7b-8bit", "firered-asr2s"]))
+
+    for identifier in ("qwen3-asr-1.7b-8bit", "firered-asr2s"):
+        materialized = pkg.load_registry()["packages"][identifier]["materialized"]
+        assert "digest_verified" not in materialized, (
+            f"{identifier} recorded a digest claim; nothing hashed it"
+        )
+
+    report = provisioner.verify()
+    assert report["failed"] == []
+    entries = {entry["package"]: entry for entry in report["verified"]}
+
+    # Hashed against a manifest pin, which one package has.
+    assert entries["silero-vad"] == {"package": "silero-vad", "digest": "ok"}
+    # Revision pinned, contents not hashed — and told apart by which key is present.
+    assert entries["qwen3-asr-1.7b-8bit"] == {
+        "package": "qwen3-asr-1.7b-8bit", "revision": QWEN_REVISION}
+    assert set(entries["firered-asr2s"]["revisions"]) == set(FIRERED_REVISIONS)
+    assert "digest" not in entries["firered-asr2s"]
+
+    # And the earned claim is still a measurement: break the bytes and it goes away.
+    Path(pkg.load_registry()["packages"]["silero-vad"]["materialized"]["path"]).write_bytes(
+        b"tampered")
+    failure = provisioner.verify()["failed"]
+    assert [item["code"] for item in failure] == ["package_integrity_failed"]
+
+
+def test_a_stale_digest_claim_in_the_registry_is_not_republished(provisioner) -> None:
+    """A root provisioned before this fix carries the fabrication in `registry.json`.
+
+    `verify` reads the registry, so forwarding `digest_verified` would let the claim survive the
+    upgrade that removed it. The revision is what gets reported either way.
+    """
+    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    document = pkg.load_registry()
+    document["packages"]["qwen3-asr-1.7b-8bit"]["materialized"]["digest_verified"] = True
+    pkg.save_registry(document)
+
+    entry = next(item for item in provisioner.verify()["verified"]
+                 if item["package"] == "qwen3-asr-1.7b-8bit")
+    assert entry == {"package": "qwen3-asr-1.7b-8bit", "revision": QWEN_REVISION}
+
+
+def test_pull_skips_what_the_registry_already_calls_ready(provisioner) -> None:
+    """Measured before this fix: a second pull of a ready package re-did all of the work."""
+    first = provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    assert first["skipped"] == []
+    assert provisioner.fetcher.snapshots == [(QWEN_REPO, QWEN_REVISION)]
+
+    second = provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    assert second["pulled"] == []
+    assert second["skipped"] == ["qwen3-asr-1.7b-8bit"]
+    assert second["environments_created"] == []
+    # Nothing was added, so nothing is claimed to have been.
+    assert second["pulled_known_bytes"] == 0
+    assert "--repair" in second["skipped_reason"]
+    assert provisioner.fetcher.snapshots == [(QWEN_REPO, QWEN_REVISION)], (
+        "the second pull re-materialized a package that was already ready"
+    )
+
+
+def test_a_ready_package_is_never_reopened_as_pulling(provisioner, monkeypatch) -> None:
+    """The cost of a pointless re-pull is not the time. It is this.
+
+    `pull` writes `state: "pulling"` before any bytes move, which is what makes a crashed pull
+    read as absent. Re-running it over a healthy package therefore downgrades that package for as
+    long as the work takes, and an interrupt leaves it downgraded.
+    """
+    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+
+    states: list[str | None] = []
+    real_save = pkg.save_registry
+
+    def spy(document: dict) -> None:
+        states.append(document["packages"].get("qwen3-asr-1.7b-8bit", {}).get("state"))
+        real_save(document)
+
+    monkeypatch.setattr(pkg, "save_registry", spy)
+    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    assert states == [], (
+        f"a no-op pull rewrote the registry, states {states}: a ready package must not be "
+        "reopened as `pulling`"
+    )
+
+
+def test_repair_re_downloads_a_hub_snapshot_a_re_pull_would_keep(tmp_path) -> None:
+    """`--repair` was declared, documented, named in four `fix` strings, and never read.
+
+    Wiring it to re-run `_materialize` is not enough by itself: `snapshot_download` returns a
+    revision the cache already holds as it stands, so without `force_download` a repair of a
+    corrupt snapshot reports success having moved no bytes.
+    """
+    fetcher = FakeFetcher(tmp_path)
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=fetcher)
+    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    weights = Path(
+        pkg.load_registry()["packages"]["qwen3-asr-1.7b-8bit"]["materialized"]["path"]
+    ) / "model.safetensors"
+    weights.write_bytes(b"bit rot")
+
+    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    assert weights.read_bytes() == b"bit rot", "a plain re-pull is not a repair"
+    assert fetcher.forced == []
+
+    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]), repair=True)
+    assert fetcher.forced == [(QWEN_REPO, QWEN_REVISION)]
+    assert weights.read_bytes() == FakeFetcher.WEIGHTS
+
+
+def test_repair_replaces_a_checkout_rather_than_patching_what_is_there(provisioner) -> None:
+    """`verify`'s `patch_not_applied` fix names `pull --repair`, so it has to actually repair."""
+    provisioner.pull(pkg.select(["vibevoice-asr-7b"]))
+    checkout = paths.checkout_dir("torch-vibevoice", "vibevoice-asr-7b")
+    patched = checkout / "vibevoice" / "modular" / "modeling_vibevoice_asr.py"
+    patched.write_text("original\n")
+    stray = checkout / "left-behind-by-a-half-finished-pull.txt"
+    stray.write_text("x")
+    assert [item["code"] for item in provisioner.verify()["failed"]] == ["patch_not_applied"]
+
+    provisioner.pull(pkg.select(["vibevoice-asr-7b"]), repair=True)
+    assert provisioner.verify()["failed"] == []
+    assert not stray.exists(), "the checkout was patched in place rather than replaced"
+
+
+def test_repair_discards_the_swift_checkout_before_rebuilding(provisioner) -> None:
+    """A rebuild in place trusts the tree whose state is what `--repair` was called about."""
+    provisioner.pull(pkg.select(["fluidaudio"]))
+    checkout = paths.checkout_dir("swift", "fluidaudio")
+    stray = checkout / "half-applied.txt"
+    stray.write_text("x")
+
+    provisioner.pull(pkg.select(["fluidaudio"]), repair=True)
+    assert not stray.exists()
+    assert (checkout / ".build" / "product").is_file()
+
+
+def test_a_url_package_needs_no_forced_download_because_it_is_hash_pinned() -> None:
+    """The one place `--repair` does nothing, and the reason it does not have to.
+
+    `url_file` re-hashes what is on disk against the manifest pin and downloads again unless it
+    matches, so a match is already the strongest re-materialization available. This runs the real
+    fetcher, not the fake, because the claim is about that code path: a matching file returns
+    without touching the network at all.
+    """
+    import urllib.request
+
+    target = paths.models_dir() / "already-correct.onnx"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"onnx-bytes")
+
+    def explode(*args, **kwargs):  # noqa: ANN002, ANN003 - a tripwire, never called
+        raise AssertionError("url_file went to the network for a file that matches its pin")
+
+    original = urllib.request.urlopen
+    urllib.request.urlopen = explode
+    try:
+        resolved = pkg.Fetcher().url_file(
+            "https://example.invalid/x.onnx", hashlib.sha256(b"onnx-bytes").hexdigest(), target)
+    finally:
+        urllib.request.urlopen = original
+    assert resolved == target
+
+    # And it is a check, not a shortcut: a file that does not match is re-fetched.
+    target.write_bytes(b"corrupt")
+    with pytest.raises(AssertionError, match="went to the network"):
+        urllib.request.urlopen = explode
+        try:
+            pkg.Fetcher().url_file(
+                "https://example.invalid/x.onnx",
+                hashlib.sha256(b"onnx-bytes").hexdigest(), target)
+        finally:
+            urllib.request.urlopen = original
+
+
+def test_a_stack_pull_provisions_around_a_missing_toolchain(tmp_path) -> None:
+    """Measured before this fix: `pull --stack qwen-1.7b` with no `swift` left `ready` empty.
+
+    `select` sorts by package id, `fluidaudio` sorts first, and `pull` raised on it — so a machine
+    without a Swift toolchain got none of the ASR weights it could have had. §0 of
+    TRANSCRIBE_HAPPY_PATH.md promises the opposite.
+    """
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(missing=("swift",)),
+                                  fetcher=FakeFetcher(tmp_path))
+    receipt = provisioner.pull(pkg.select(stack="qwen-1.7b"), stack="qwen-1.7b")
+
+    pulled = [entry["package"] for entry in receipt["pulled"]]
+    assert "qwen3-asr-1.7b-8bit" in pulled and "qwen3-forcedaligner" in pulled
+    assert "fluidaudio" not in pulled
+
+    blocked = next(item for item in receipt["warnings"]
+                   if item["code"] == "toolchain_missing")
+    assert blocked["blocking"] is True
+    assert blocked["packages"] == ["fluidaudio"]
+    assert blocked["requires_tool"] == ["swift"]
+    assert "qwen-1.7b" in blocked["detail"]
+
+    document = pkg.load_registry()
+    assert pkg.is_ready(document, "qwen3-asr-1.7b-8bit")
+    assert "fluidaudio" not in document["packages"], "a blocked package left a registry entry"
+    # A blocked package provisioned nothing, so it claims no license and no bytes.
+    licenses = next(item for item in receipt["warnings"]
+                    if item["code"] == "license_unreviewed")
+    assert "fluidaudio" not in licenses["packages"]
+    assert receipt["pulled_known_bytes"] > 0
+
+
+def test_naming_a_toolchain_blocked_package_is_still_exit_three(tmp_path) -> None:
+    """The asymmetry: a stack is a superset guess, a named package is an instruction."""
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(missing=("swift",)),
+                                  fetcher=FakeFetcher(tmp_path))
+    with pytest.raises(pkg.ProvisioningError) as caught:
+        provisioner.pull(pkg.select(["fluidaudio"]))
+    assert caught.value.code == "toolchain_missing"
+    assert caught.value.exit_code == 3
+    assert caught.value.payload["requires_tool"] == ["swift"]
+
+    # And a stack in which nothing at all was provisionable is exit 3 too, because there is no
+    # partial success to report. No shipped stack is one package wide, so the selection is
+    # constructed rather than selected.
+    with pytest.raises(pkg.ProvisioningError) as caught:
+        provisioner.pull(pkg.select(["fluidaudio"]), stack="qwen-1.7b")
+    assert caught.value.exit_code == 3
+
+
+def test_teardown_never_deletes_a_sibling_of_the_models_directory(tmp_path) -> None:
+    """`str(models_dir) in path` is a substring test where a prefix test was meant.
+
+    Point the Hub cache at `<root>/models_hub` — one plausible `HF_HOME` — and every snapshot
+    under it tests positive, so `_locations` hands the shared cache to `_delete`. The revision
+    below was in the cache before this root wanted it, which is exactly the case teardown
+    promises to retain.
+    """
+    class HubBesideModels(FakeFetcher):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.hub = Path(str(paths.models_dir()) + "_hub")
+
+    fetcher = HubBesideModels(tmp_path, already_cached=(QWEN_REVISION,))
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=fetcher)
+    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit", "silero-vad"]))
+
+    snapshot = Path(
+        pkg.load_registry()["packages"]["qwen3-asr-1.7b-8bit"]["materialized"]["path"])
+    artifact = Path(pkg.load_registry()["packages"]["silero-vad"]["materialized"]["path"])
+    assert str(paths.models_dir()) in str(snapshot), "the fixture no longer sets the trap"
+
+    report = provisioner.remove(["qwen3-asr-1.7b-8bit", "silero-vad"])
+    assert report["hub_revisions_retained"] == [QWEN_REVISION]
+    assert snapshot.is_dir(), "teardown deleted a directory inside the shared Hugging Face cache"
+    # The true positive still holds, or the fix would be "delete nothing".
+    assert not artifact.exists(), "the artifact this root wrote under models/ was not reclaimed"
+
+
+def test_want_is_refused_rather_than_accepted_and_ignored(capsys) -> None:
+    """`--want` reached no code that could honour it. TRANSCRIBE_HAPPY_PATH.md §4.6 on why."""
+    assert main(["packages", "pull", "--stack", "qwen-1.7b", "--want", "diarization"]) == 2
+    error = json.loads(capsys.readouterr().err)["error"]
+    assert error["code"] == "want_not_implemented"
+    assert error["field"] == "--want"
+    assert error["provided"] == "diarization"
+    assert error["fix"] == "audio packages pull --stack qwen-1.7b"
+    assert pkg.load_registry()["packages"] == {}, "the refused command provisioned something"
+
+    # Without --stack it is still the older refusal, whose fix no longer suggests --want either.
+    assert main(["packages", "pull", "--want", "diarization"]) == 2
+    error = json.loads(capsys.readouterr().err)["error"]
+    assert error["code"] == "stack_required"
+    assert "--want" not in error["fix"]
+
+
+def test_a_stack_beside_named_packages_is_a_conflict_not_a_precedence(capsys) -> None:
+    """`select` returned early on package ids and dropped `--stack` silently."""
+    with pytest.raises(pkg.ProvisioningError) as caught:
+        pkg.select(["silero-vad"], stack="qwen-1.7b")
+    assert caught.value.code == "stack_conflicts_with_named_packages"
+    assert caught.value.exit_code == 2
+    assert caught.value.payload["stack"] == "qwen-1.7b"
+    assert caught.value.payload["packages"] == ["silero-vad"]
+    assert caught.value.payload["fix"] == "audio packages pull silero-vad"
+
+    assert main(["packages", "pull", "--stack", "qwen-1.7b", "silero-vad"]) == 2
+    assert json.loads(capsys.readouterr().err)["error"]["code"] == \
+        "stack_conflicts_with_named_packages"
+
+
+def test_the_cli_hands_repair_and_the_stack_through_to_pull(monkeypatch, capsys) -> None:
+    """The wiring the flags were missing: `--repair` was parsed and read by nothing.
+
+    `--stack` has to reach `pull` as well, because it is what decides whether a toolchain-blocked
+    package is a warning or an exit 3.
+    """
+    seen: dict[str, object] = {}
+
+    class Recorder:
+        def pull(self, selection, *, repair: bool = False, stack: str | None = None) -> dict:
+            seen.update(packages=[package.id for package in selection], repair=repair,
+                        stack=stack)
+            return {"pulled": [], "skipped": [], "warnings": []}
+
+    monkeypatch.setattr("audio_cli.cli.Provisioner", Recorder)
+
+    assert main(["packages", "pull", "--repair", "silero-vad"]) == 0
+    capsys.readouterr()
+    assert seen == {"packages": ["silero-vad"], "repair": True, "stack": None}
+
+    assert main(["packages", "pull", "--stack", "firered"]) == 0
+    capsys.readouterr()
+    assert seen["stack"] == "firered"
+    assert seen["repair"] is False
+    assert seen["packages"] == ["firered-asr2s", "fluidaudio", "speaker-diarization-coreml"]

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -7,6 +7,11 @@ digest verification, and every payload shape the spec documents publish.
 
 The one thing a fake cannot check is whether the real `uv` and Hub calls work. Those are
 exercised by the provisioning probes in `model_tests/benchmark/` and recorded there.
+
+What a fake here *must* be able to represent is the state a repair produces. Both doubles below
+say so at the point where it matters, because both were wrong about it once: a double that always
+rewrites a snapshot, or that can never stop being drifted, turns a repair test green without the
+repair ever running.
 """
 
 from __future__ import annotations
@@ -33,13 +38,26 @@ def isolated_root(tmp_path, monkeypatch):
 
 
 class FakeToolchain(pkg.Toolchain):
-    """Records what would have been run, and pretends it succeeded."""
+    """Records what would have been run, and pretends it succeeded.
 
-    def __init__(self, *, missing: tuple[str, ...] = (), drift: dict | None = None) -> None:
+    Drift is *clearable state*, which is the one thing this double has to get right. `uv pip
+    sync` is convergent — it makes an environment equal to its lock (ENVIRONMENTS.md) — so an
+    environment that has just been recreated cannot still be drifted. This applied `drift`
+    unconditionally and never cleared it, which made a repaired environment unrepresentable: the
+    only way to observe `ok` was to swap in a second toolchain, and a test doing that never
+    executes `verify`'s repair branch at all. Same standard as `FakeFetcher.hf_snapshot` below,
+    for the same reason: a double that cannot represent the state a repair produces makes a
+    broken repair pass.
+    """
+
+    def __init__(self, *, missing: tuple[str, ...] = (), drift: dict | None = None,
+                 private_api_hash: str | None = None) -> None:
         self.calls: list[list[str]] = []
         self.missing = set(missing)
-        self._drift = drift or {}
+        self._drift = dict(drift or {})
         self.created: list[str] = []
+        self._synced: set[str] = set()
+        self.private_api_hash = private_api_hash
 
     def which(self, tool: str) -> str | None:
         return None if tool in self.missing else f"/usr/bin/{tool}"
@@ -52,17 +70,30 @@ class FakeToolchain(pkg.Toolchain):
             stdout = ""
             stderr = ""
 
+        # Opt-in, because the default has to keep yielding *no* verdict: that is the path
+        # `mlx_audio_private_api_error` covers, and the exemption for it in
+        # tests/test_shipped_commands_match_the_document.py has to stay reachable. The only
+        # `-c` invocation in the tool is the private-API probe.
+        if self.private_api_hash is not None and list(args)[1:2] == ["-c"]:
+            guards = {guard["kind"]: guard for guard in env.environments()["mlx"].guards}
+            Result.stdout = json.dumps({
+                "sha256": self.private_api_hash,
+                "params": sorted(guards["signature"]["required_parameters"]),
+            })
         return Result()
 
     def create_environment(self, environment, target: Path) -> None:
         self.created.append(environment.name)
         (target / "bin").mkdir(parents=True, exist_ok=True)
         (target / "bin" / "python").write_text("#!/bin/sh\n")
+        # Re-syncing from the lock is what removes drift, so this is where it goes.
+        self._synced.add(environment.name)
 
     def frozen_packages(self, environment_python: Path) -> dict[str, str]:
         name = environment_python.parent.parent.name
         installed = pkg._locked_versions(env.environments()[name])
-        installed.update(self._drift)
+        if name not in self._synced:
+            installed.update(self._drift)
         return installed
 
     def clone(self, repo: str, commit: str, target: Path) -> None:
@@ -333,21 +364,37 @@ def test_verify_reports_a_reverted_patch(provisioner) -> None:
 
 
 def test_verify_reports_a_drifted_environment_and_repairs_it(tmp_path) -> None:
-    provisioner = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=FakeFetcher(tmp_path))
-    provisioner.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    """One provisioner, drifted before and `ok` after, with evidence the repair path ran.
 
-    drifted = pkg.Provisioner(
-        toolchain=FakeToolchain(drift={"mlx": "0.31.0"}),
-        fetcher=FakeFetcher(tmp_path),
-    )
-    report = drifted.verify()
+    This used to assert the second half against a *different* toolchain, which reports `ok` with
+    or without the flag — so `repair=True` was decorative and `verify`'s `if drift and repair`
+    branch never executed. Note `"mlx"` here is the pip package whose lock pins 0.32.0, not the
+    environment that happens to share its name.
+    """
+    pkg.Provisioner(toolchain=FakeToolchain(), fetcher=FakeFetcher(tmp_path)).pull(
+        pkg.select(["qwen3-asr-1.7b-8bit"]))
+
+    toolchain = FakeToolchain(drift={"mlx": "0.31.0"})
+    provisioner = pkg.Provisioner(toolchain=toolchain, fetcher=FakeFetcher(tmp_path))
+
+    report = provisioner.verify()
     assert report["environments"]["mlx"] == "drifted"
     assert report["failed"][0]["code"] == "environment_drifted"
     assert report["failed"][0]["examples"]["mlx"] == {"locked": "0.32.0", "installed": "0.31.0"}
     assert report["failed"][0]["fix"] == "audio packages verify --repair"
+    # Reported, not repaired: the flag is what re-syncs, so without it the state persists and a
+    # second look says the same thing rather than the report having consumed it.
+    assert toolchain.created == [], "verify without --repair re-synced an environment"
+    assert provisioner.verify()["environments"]["mlx"] == "drifted"
 
-    repaired = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=FakeFetcher(tmp_path))
-    assert repaired.verify(repair=True)["environments"]["mlx"] == "ok"
+    repaired = provisioner.verify(repair=True)
+    assert repaired["environments"]["mlx"] == "ok"
+    assert repaired["failed"] == []
+    assert toolchain.created == ["mlx"], (
+        "the environment was never re-synced, so nothing repaired the drift"
+    )
+    # And it stayed repaired, which is what distinguishes a re-sync from a suppressed report.
+    assert provisioner.verify()["environments"]["mlx"] == "ok"
 
 
 def test_verify_reports_a_corrupted_single_file_artifact(tmp_path) -> None:
@@ -1088,3 +1135,87 @@ def test_a_teardown_that_dies_leaves_no_package_reading_as_ready(tmp_path) -> No
         assert pkg.load_registry()["packages"] == {}, (
             f"{teardown} left a package reading as ready with its bytes already deleted"
         )
+
+
+def test_verify_compares_the_private_api_hash_when_the_environment_answers(tmp_path) -> None:
+    """The guard's *passing* verdict was unreachable: every test only ever observed `None`.
+
+    A fake interpreter that never answers exercises the no-verdict path and nothing else, so a
+    regression that stopped comparing — or compared against the wrong value — would have looked
+    exactly like a clean run. §1.3 publishes `matches_expected: true`, so something has to be able
+    to produce it. Found while scanning for the vacuous-flag shape; it is the same family.
+    """
+    expected = {guard["kind"]: guard
+                for guard in env.environments()["mlx"].guards}["source_hash"]["sha256"]
+
+    answering = pkg.Provisioner(toolchain=FakeToolchain(private_api_hash=expected),
+                                fetcher=FakeFetcher(tmp_path))
+    answering.pull(pkg.select(["qwen3-asr-1.7b-8bit"]))
+    report = answering.verify()
+    assert report["mlx_audio_private_api_source_hash"] == expected
+    assert report["mlx_audio_private_api_matches_expected"] is True
+    assert report["mlx_audio_private_api_signature_ok"] is True
+    assert "mlx_audio_private_api_error" not in report
+
+    # And it is a comparison rather than an echo: a source file that moved fails it, with both
+    # values published so a reader can see why.
+    moved = pkg.Provisioner(toolchain=FakeToolchain(private_api_hash="0" * 64),
+                            fetcher=FakeFetcher(tmp_path))
+    report = moved.verify()
+    assert report["mlx_audio_private_api_source_hash"] == "0" * 64
+    assert report["mlx_audio_private_api_matches_expected"] is False
+    assert report["mlx_audio_private_api_expected_source_hash"] == expected
+    # Stated, not fixed: a moved private API is reported and does not reach `failed`, so `verify`
+    # still exits 0. Whether it should is a contract decision, recorded in HANDOFF.md.
+    assert report["failed"] == []
+
+
+def test_repair_forces_every_repository_of_a_multi_repo_package(tmp_path) -> None:
+    """A repair that forced only the first of four repositories would leave the rot in place.
+
+    The single-repo test cannot see this: `huggingface` and `huggingface_multi` pass `force`
+    through separate code, and a mutation scan showed nothing asserted the second one.
+    """
+    fetcher = FakeFetcher(tmp_path)
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=fetcher)
+    provisioner.pull(pkg.select(["firered-asr2s"]))
+    snapshots = pkg.load_registry()["packages"]["firered-asr2s"]["materialized"]["paths"]
+    weights = [Path(location) / "model.safetensors" for location in snapshots.values()]
+    assert len(weights) == 4
+    for artifact in weights:
+        artifact.write_bytes(b"bit rot")
+
+    provisioner.pull(pkg.select(["firered-asr2s"]), repair=True)
+    assert {revision for _, revision in fetcher.forced} == set(FIRERED_REVISIONS)
+    assert all(artifact.read_bytes() == FakeFetcher.WEIGHTS for artifact in weights), (
+        "a repair left at least one of the four repositories unfetched"
+    )
+
+
+def test_the_cli_hands_repair_and_dry_run_to_verify_and_purge(monkeypatch, capsys) -> None:
+    """The rest of the flag wiring, for the same reason `--repair` on `pull` needed it.
+
+    `--dry-run` is the one where a dropped argument is destructive: a caller asking what a purge
+    would reclaim would have it reclaimed.
+    """
+    seen: dict[str, object] = {}
+
+    class Recorder:
+        def verify(self, *, repair: bool = False) -> dict:
+            seen["verify_repair"] = repair
+            return {"verified": [], "environments": {}, "failed": []}
+
+        def purge(self, *, dry_run: bool) -> dict:
+            seen["purge_dry_run"] = dry_run
+            return {"removed": {}}
+
+    monkeypatch.setattr("audio_cli.cli.Provisioner", Recorder)
+    for argv, key, expected in (
+        (["packages", "verify"], "verify_repair", False),
+        (["packages", "verify", "--repair"], "verify_repair", True),
+        (["packages", "purge"], "purge_dry_run", False),
+        (["packages", "purge", "--dry-run"], "purge_dry_run", True),
+    ):
+        assert main(argv) == 0
+        capsys.readouterr()
+        assert seen[key] is expected, f"{' '.join(argv)} reached the provisioner as {seen[key]!r}"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -945,3 +945,69 @@ def test_the_cli_hands_repair_and_the_stack_through_to_pull(monkeypatch, capsys)
     assert seen["stack"] == "firered"
     assert seen["repair"] is False
     assert seen["packages"] == ["firered-asr2s", "fluidaudio", "speaker-diarization-coreml"]
+
+
+def test_verify_does_not_call_an_environment_ok_when_its_toolchain_is_absent(
+    tmp_path, the_fake_download_satisfies_the_pin
+) -> None:
+    """A state that only became reachable once a stack pull stopped aborting on a blocked package.
+
+    `speaker-diarization-coreml` needs no toolchain of its own, so it lands in `swift` and marks
+    that environment `ready` while `fluidaudio` stays blocked. Nothing in it can run: this tool
+    launches the built product through `swift run`. A caller dispatching on `swift: "ok"` would
+    conclude diarization is available on a machine that cannot do it.
+    """
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(missing=("swift",)),
+                                  fetcher=FakeFetcher(tmp_path))
+    provisioner.pull(pkg.select(stack="qwen-1.7b"), stack="qwen-1.7b")
+    assert pkg.load_registry()["environments"]["swift"]["state"] == "ready", (
+        "the fixture no longer reaches the state under test"
+    )
+
+    report = provisioner.verify()
+    assert report["environments"]["swift"] == "blocked"
+    assert report["environments"]["mlx"] == "ok"
+    # Exit 0, deliberately: `verify` exits 3 on `failed`, and this is not a broken check. The
+    # missing package is one `list` reports as absent, and no `audio` command installs Swift.
+    assert report["failed"] == []
+
+    # And it is a claim about the toolchain, not about the root: the same registry verifies `ok`
+    # once `swift` is back, with nothing re-pulled.
+    restored = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=FakeFetcher(tmp_path))
+    assert restored.verify()["environments"]["swift"] == "ok"
+
+
+def test_a_blocked_environment_outranks_the_checks_it_would_prevent(tmp_path) -> None:
+    """`blocked` replaces a verdict, and only a verdict.
+
+    An environment nobody has provisioned stays `absent` — that is not a claim of usability and
+    it is what `pull` acts on. The word replaces `ok` and `drifted`, which are statements about
+    checks that passed or failed, and it outranks them because a repair that needs the missing
+    tool is not a repair a caller can run.
+    """
+    absent_root = pkg.Provisioner(toolchain=FakeToolchain(missing=("swift",)),
+                                  fetcher=FakeFetcher(tmp_path))
+    assert absent_root.verify()["environments"]["swift"] == "absent"
+
+    absent_root.pull(pkg.select(["speaker-diarization-coreml"]))
+    assert absent_root.verify()["environments"]["swift"] == "blocked"
+
+
+def test_vocabulary_names_every_environment_state_verify_can_emit() -> None:
+    """VOCABULARY.md is the naming contract, so a new enum member cannot land unregistered.
+
+    Derived from the source rather than listed by hand: a member added to `verify` without a
+    line in the contract fails the first assertion, and one added to both without the backticked
+    spelling fails the second.
+    """
+    import re
+
+    emitted = set(re.findall(r'environment_states\[name\] = "(\w+)"',
+                             Path(pkg.__file__).read_text()))
+    assert emitted == {"absent", "ok", "drifted", "blocked"}, (
+        f"verify emits environment states {sorted(emitted)}; register the new one in "
+        "VOCABULARY.md and add it here"
+    )
+    vocabulary = (Path(__file__).resolve().parents[1] / "VOCABULARY.md").read_text()
+    for state in sorted(emitted):
+        assert f"`{state}`" in vocabulary, f"VOCABULARY.md does not name the {state!r} state"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -115,7 +115,7 @@ class FakeToolchain(pkg.Toolchain):
         (checkout / ".build").mkdir(parents=True, exist_ok=True)
         (checkout / ".build" / "product").write_bytes(b"x" * 1024)
 
-    def swift_product_runs(self, checkout: Path) -> bool:
+    def swift_product_runs(self, checkout: Path, product: str) -> bool:
         return True
 
 
@@ -1219,3 +1219,100 @@ def test_the_cli_hands_repair_and_dry_run_to_verify_and_purge(monkeypatch, capsy
         assert main(argv) == 0
         capsys.readouterr()
         assert seen[key] is expected, f"{' '.join(argv)} reached the provisioner as {seen[key]!r}"
+
+
+def test_every_built_package_pins_the_product_it_has_to_launch() -> None:
+    """The defect this catches: the executable's name living in a runner instead of the manifest.
+
+    `swift_product_runs` ran `swift run ... fluidaudio` while Package.swift at the pinned commit
+    declares `.executable(name: "fluidaudiocli")`, so the check answered "no executable product
+    named 'fluidaudio'" on a perfectly good build and could never return True. Pinning the name
+    beside the commit makes it reviewable when the commit moves.
+    """
+    built = {identifier: package for identifier, package in env.packages().items()
+             if package.source["type"] == "git+build"}
+    assert built, "no git+build package, so this invariant has nothing to hold"
+    for identifier, package in built.items():
+        assert package.source.get("product"), (
+            f"{identifier} is built from source but names no product to launch"
+        )
+
+
+def test_the_pinned_product_name_is_the_one_launched(tmp_path) -> None:
+    """A pinned name that the runner ignores would be decoration."""
+    launched: list[str] = []
+
+    class Recording(FakeToolchain):
+        def swift_product_runs(self, checkout: Path, product: str) -> bool:
+            launched.append(product)
+            return True
+
+    provisioner = pkg.Provisioner(toolchain=Recording(), fetcher=FakeFetcher(tmp_path))
+    provisioner.pull(pkg.select(["fluidaudio"]))
+    assert launched == [env.packages()["fluidaudio"].source["product"]]
+
+
+def test_a_build_whose_product_cannot_run_is_not_a_provisioned_package(tmp_path) -> None:
+    """The defect this catches: `product_runs: false` recorded and then ignored.
+
+    `pull` returned exit 0 with an empty `warnings`, `verify` reported `failed: []`, and the
+    environment read `ok`, while the one thing the package exists for was impossible.
+    """
+    class Broken(FakeToolchain):
+        def swift_product_runs(self, checkout: Path, product: str) -> bool:
+            return False
+
+    provisioner = pkg.Provisioner(toolchain=Broken(), fetcher=FakeFetcher(tmp_path))
+    with pytest.raises(pkg.ProvisioningError) as caught:
+        provisioner.pull(pkg.select(["fluidaudio"]))
+    assert caught.value.code == "package_build_unusable"
+    assert caught.value.exit_code == 3
+    assert caught.value.payload["product"] == "fluidaudiocli"
+    assert caught.value.payload["fix"] == "audio packages pull --repair fluidaudio"
+    # Fails closed: the entry never reaches `ready`, so `list` and `run` both call it absent.
+    assert not pkg.is_ready(pkg.load_registry(), "fluidaudio")
+
+
+def test_verify_fails_a_registry_that_recorded_an_unusable_build(tmp_path) -> None:
+    """Reachable from a registry written before `pull` started refusing this."""
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=FakeFetcher(tmp_path))
+    provisioner.pull(pkg.select(["fluidaudio"]))
+
+    document = pkg.load_registry()
+    document["packages"]["fluidaudio"]["materialized"]["product_runs"] = False
+    pkg.save_registry(document)
+
+    report = provisioner.verify()
+    failure = [entry for entry in report["failed"] if entry["package"] == "fluidaudio"]
+    assert failure, "verify passed a package whose product does not run"
+    assert failure[0]["code"] == "package_build_unusable"
+    assert failure[0]["fix"] == "audio packages pull --repair fluidaudio"
+    assert not [v for v in report["verified"] if v["package"] == "fluidaudio"], (
+        "the same package was both verified and failed"
+    )
+
+
+def test_the_real_toolchain_launches_the_product_it_was_given(tmp_path) -> None:
+    """The assertion that would have caught the original defect, and the one above does not.
+
+    A double that replaces `swift_product_runs` only proves `_materialize` passes the pinned name;
+    the bug was inside the method, which ignored its surroundings and ran a literal. So this
+    exercises the real body and overrides `run` alone.
+    """
+    commands: list[list[str]] = []
+
+    class RecordingRun(pkg.Toolchain):
+        def run(self, args, *, cwd=None, timeout=3600):
+            commands.append(list(args))
+
+            class Result:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return Result()
+
+    assert RecordingRun().swift_product_runs(tmp_path, "fluidaudiocli") is True
+    assert commands == [["swift", "run", "-c", "release", "fluidaudiocli", "--help"]], (
+        f"the product argument did not reach the command: {commands}"
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from scipy.io import wavfile
 
 import audio_cli.pipeline as pipeline_module
-from audio_cli.pipeline import EnhancementPipeline
+from audio_cli.media import is_enhanced_media, probe_media
+from audio_cli.pipeline import EnhancementPipeline, PipelineError
 from audio_cli.profiles import PROFILES, STAGE_ORDER
 from audio_cli.vad import SpeechRegion
 
@@ -105,3 +107,35 @@ def test_pipeline_never_corrects_a_machine_region_that_overlaps_speech(
     assert all(
         final_evaluations[region_id] == "abstained_overlap" for region_id in abstained
     )
+
+
+def test_an_enhanced_render_is_refused_as_input_unless_it_is_allowed(tmp_path) -> None:
+    """The original media is canonical, so re-enhancing a render takes an explicit override.
+
+    Nothing asserted the guard: a mutation scan turned `allow_enhanced_input` into a no-op and the
+    suite stayed green, which would have let a second pass compound on a first. No fake probe here
+    — the render's own `comment` tag carries the marker the guard reads, so this is the round trip
+    a caller would actually make.
+    """
+    sample_rate = 48_000
+    time = np.arange(round(sample_rate * 4.0)) / sample_rate
+    audio = np.zeros((time.size, 2), dtype=np.float32)
+    speech = (time >= 1.5) & (time < 3.5)
+    audio[speech] = (0.02 * np.sin(2 * np.pi * 180 * time[speech]))[:, None]
+    source = tmp_path / "source.wav"
+    wavfile.write(source, sample_rate, audio)
+
+    pipeline = EnhancementPipeline(PROFILES["product-demo"], detector=FakeVad())
+    once = tmp_path / "once.wav"
+    pipeline.run(source, output=once, dry_run=False)
+    assert is_enhanced_media(probe_media(once)), "the render carries no marker to refuse"
+    assert not is_enhanced_media(probe_media(source))
+
+    twice = tmp_path / "twice.wav"
+    with pytest.raises(PipelineError, match="enhanced render"):
+        pipeline.run(once, output=twice, dry_run=False)
+    assert not twice.exists()
+
+    report = pipeline.run(once, output=twice, dry_run=False, allow_enhanced_input=True)
+    assert report["rendered"] is True
+    assert twice.is_file()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -139,3 +139,40 @@ def test_an_enhanced_render_is_refused_as_input_unless_it_is_allowed(tmp_path) -
     report = pipeline.run(once, output=twice, dry_run=False, allow_enhanced_input=True)
     assert report["rendered"] is True
     assert twice.is_file()
+
+
+@pytest.mark.parametrize(
+    "samples_48k",
+    [1332160, 48_000, 48_001, 12_345, 99_999, 1, 512],
+)
+def test_the_vad_timeline_never_runs_past_the_source(samples_48k: int) -> None:
+    """The defect this catches: a speech bound published outside the media.
+
+    `resample_poly` returns `ceil(n * up / down)`, so 1332160 samples at 48 kHz became 444054 at
+    16 kHz where the exact figure is 444053.333. A region running to the end of that signal was
+    published ending at 27.753375 s in a 27.753333 s file -- a bound the source does not have --
+    and the treatment clamp that pulled it back then reported a negative extension, contradicting
+    the guarantee that speech effects are fully engaged at the last detected sample.
+    """
+    audio = np.zeros((samples_48k, 1), dtype=np.float32)
+    vad = pipeline_module._vad_audio(audio, 48_000)
+
+    assert vad.size / 16_000 <= samples_48k / 48_000 + 1e-12, (
+        f"{samples_48k} samples at 48 kHz became {vad.size} at 16 kHz, which is "
+        f"{vad.size / 16_000:.9f} s of timeline for a {samples_48k / 48_000:.9f} s source"
+    )
+
+
+def test_a_source_already_at_16k_is_passed_through_whole() -> None:
+    """The truncation must not eat a sample when no resampling happens."""
+    audio = np.zeros((16_000, 1), dtype=np.float32)
+    assert pipeline_module._vad_audio(audio, 16_000).size == 16_000
+
+
+def test_the_vad_timeline_loses_at_most_one_sample() -> None:
+    """Truncating is the safe direction, but it must not become a habit of discarding tail."""
+    samples_48k = 1332160
+    audio = np.zeros((samples_48k, 1), dtype=np.float32)
+    vad = pipeline_module._vad_audio(audio, 48_000)
+    exact = samples_48k * 16_000 / 48_000
+    assert exact - vad.size < 1.0, f"dropped {exact - vad.size:.3f} samples of tail"

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -13,7 +13,7 @@ def test_profiles_version_the_complete_fixed_order() -> None:
     assert PROFILES["product-demo"].source_balance_enabled is True
     assert PROFILES["transcription"].source_balance_enabled is False
     for profile in PROFILES.values():
-        assert profile.version == "3"
+        assert profile.version == "4"
         assert profile.speech_transition_placement == "outside"
         assert profile.as_dict()["processing_order"] == list(STAGE_ORDER)
 

--- a/tests/test_shipped_commands_match_the_document.py
+++ b/tests/test_shipped_commands_match_the_document.py
@@ -1,0 +1,229 @@
+"""The commands that already ship, against the shapes `TRANSCRIBE_HAPPY_PATH.md` publishes.
+
+Most blocks in that document mock a command that does not exist yet, so `tests/test_spec_docs.py`
+can only check the documents against each other. `doctor`, `packages list`, and `packages verify`
+ship, which makes them the first places the document can be *wrong* rather than merely unbuilt.
+
+All three were. §0 described `external_tools` carrying version strings, flat `"mlx": "absent"`
+environment states, `packages` as a `{provisioned, count}` pair, and a top-level `warnings` array,
+none of which `doctor` emits. §5 omitted the `state` `list` reports per package. §1.3 published
+`matches_expected: true` without the expected hash `verify` prints beside it.
+
+Nothing caught any of it. `test_spec_docs.py` compares the documents to each other and
+`test_packages.py` compares each command to its own output, so the one comparison that mattered
+existed nowhere. This is that comparison, and it is the pattern the `transcribe` acceptance
+criterion needs later: a plan's `sample_output` key set against a real run's.
+
+Structure only. The documents' paths, versions, and counters are illustrative by their own
+declaration; their key sets and nesting are the part that must match.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from audio_cli import packages as pkg
+
+REPO = Path(__file__).resolve().parents[1]
+HAPPY_PATH = REPO / "TRANSCRIBE_HAPPY_PATH.md"
+
+
+@pytest.fixture(autouse=True)
+def isolated_root(tmp_path, monkeypatch):
+    """The document shows an unprovisioned machine, and so must this."""
+    monkeypatch.setenv("AUDIO_PROCESSING_MODEL_CACHE", str(tmp_path / "root"))
+
+
+class StubToolchain(pkg.Toolchain):
+    """Present tools, no subprocesses. §0 is the everything-installed case."""
+
+    def which(self, tool: str) -> str | None:
+        return f"/usr/bin/{tool}"
+
+
+def documented_doctor() -> dict:
+    """The one JSON block under §0."""
+    text = HAPPY_PATH.read_text()
+    section = text.index("## 0. Once per machine")
+    block = re.search(r"```json\n(.*?)```", text[section:], re.S)
+    assert block is not None, "TRANSCRIBE_HAPPY_PATH.md §0 no longer publishes a JSON block"
+    return json.loads(block.group(1))
+
+
+def shape(node, trail: str = "") -> dict[str, str]:
+    """Every leaf's path mapped to its JSON type. Dict keys are part of the path."""
+    if isinstance(node, dict):
+        found: dict[str, str] = {}
+        for key, value in node.items():
+            found.update(shape(value, f"{trail}.{key}" if trail else key))
+        return found
+    if isinstance(node, list):
+        # Cardinality is never promised; the element shape is. An empty list is its own leaf,
+        # because there is no element to describe.
+        #
+        # Elements are unioned, not intersected, because they legitimately differ -- `fluidaudio`
+        # carries `bytes: null` where a weights package carries a count, and a failed `verify`
+        # entry carries different keys than a passing one. The cost of that choice, stated so it
+        # is not mistaken for coverage: a key dropped from *some* elements of a documented array
+        # stays invisible. Only a key dropped from all of them fails.
+        if not node:
+            return {f"{trail}[]": "empty"}
+        merged: dict[str, str] = {}
+        for item in node:
+            merged.update(shape(item, f"{trail}[]"))
+        return merged
+    return {trail: type(node).__name__}
+
+
+COMPATIBLE = {"empty", "list"}
+
+
+def test_doctor_emits_the_shape_the_document_publishes() -> None:
+    """The defect this catches: §0 describing a doctor payload that doctor does not emit."""
+    documented = shape(documented_doctor())
+    actual = shape(pkg.doctor(toolchain=StubToolchain()))
+
+    undocumented = sorted(set(actual) - set(documented))
+    unimplemented = sorted(set(documented) - set(actual))
+    assert not undocumented, (
+        "audio doctor emits fields TRANSCRIBE_HAPPY_PATH.md §0 does not publish: "
+        f"{undocumented}"
+    )
+    assert not unimplemented, (
+        "TRANSCRIBE_HAPPY_PATH.md §0 publishes fields audio doctor does not emit: "
+        f"{unimplemented}"
+    )
+
+    # A nullable field is legitimately null on one side and populated on the other, so NoneType
+    # agrees with anything. Everything else has to agree on type, which is what keeps a count
+    # from being documented as a string.
+    for trail, documented_type in sorted(documented.items()):
+        actual_type = actual[trail]
+        if "NoneType" in (documented_type, actual_type):
+            continue
+        if {documented_type, actual_type} <= COMPATIBLE:
+            continue
+        assert documented_type == actual_type, (
+            f"{trail}: §0 publishes {documented_type}, audio doctor emits {actual_type}"
+        )
+
+
+def test_the_document_names_every_environment_and_package_doctor_reports() -> None:
+    """Key-for-key on the two maps that grow: a new package must be documented to land."""
+    documented = documented_doctor()
+    actual = pkg.doctor(toolchain=StubToolchain())
+    for field in ("environments", "packages", "tools"):
+        assert sorted(documented[field]) == sorted(actual[field]), (
+            f"§0's {field} names {sorted(documented[field])}; "
+            f"doctor reports {sorted(actual[field])}"
+        )
+
+
+def provisioned_like_the_document(tmp_path: Path) -> pkg.Provisioner:
+    """A root holding every package, so `list` and `verify` print their populated shape.
+
+    `doctor` reports the same keys whatever is provisioned, so it needs no fixture. These two do
+    not: an empty root prints an empty `packages` array, and an array with no element promises no
+    element shape. The document's blocks depict a fully-provisioned machine, so the fixture has to
+    be one.
+    """
+    from test_packages import FakeFetcher, FakeToolchain  # sibling module, same rootdir
+
+    provisioner = pkg.Provisioner(toolchain=FakeToolchain(), fetcher=FakeFetcher(tmp_path))
+    provisioner.pull(list(pkg.select(stack="qwen-1.7b")))
+    provisioner.pull(list(pkg.select(stack="firered")))
+    provisioner.pull(list(pkg.select(stack="vibevoice")))
+    return provisioner
+
+
+def documented_block(anchor: str) -> dict:
+    text = HAPPY_PATH.read_text()
+    block = re.search(r"```json\n(.*?)```", text[text.index(anchor):], re.S)
+    assert block is not None, f"the document no longer publishes a JSON block at {anchor!r}"
+    return json.loads(block.group(1))
+
+
+def test_packages_list_emits_exactly_the_shape_the_document_publishes(tmp_path) -> None:
+    """The defect this catches: the same drift as `doctor`, one command over.
+
+    It was there: `list` emits a `state` per package that §5 did not publish.
+    """
+    provisioned_like_the_document(tmp_path)
+    documented = shape(documented_block("## 5. Teardown"))
+    actual = shape(pkg.list_report())
+
+    assert sorted(set(actual) - set(documented)) == [], (
+        "audio packages list emits fields §5 does not publish: "
+        f"{sorted(set(actual) - set(documented))}"
+    )
+    assert sorted(set(documented) - set(actual)) == [], (
+        "§5 publishes fields audio packages list does not emit: "
+        f"{sorted(set(documented) - set(actual))}"
+    )
+
+
+# Keys `verify` emits only when a check fails or cannot run. §1.3 is the happy path, so it
+# legitimately shows none of them, and a fake fetcher legitimately triggers them. Each is listed
+# with the reason it is exempt, so the exemption is a decision rather than a hole -- a genuinely
+# new key is still a failure.
+VERIFY_CONDITIONAL = {
+    # Shape disputed: TRANSCRIBE_CONTRACT.md §64 declares (package, check, expected, actual)
+    # and the implementation emits (package, code, detail, fix). Until that is ruled on, this
+    # test does not ratify either side by asserting on it.
+    "failed[].package", "failed[].code", "failed[].detail", "failed[].fix",
+    # Absence is meaningful: set when the interpreter yields no verdict, so that
+    # `matches_expected: null` cannot read as a passing check.
+    "mlx_audio_private_api_error",
+}
+
+
+def test_packages_verify_emits_no_field_the_document_does_not_publish(tmp_path) -> None:
+    """The defect this catches: `verify` publishing a claim §1.3 never described.
+
+    It was there: `verify` emits the expected private-API hash beside the measured one, where
+    §1.3 published only the measured -- so `matches_expected: true` was unreproducible by eye.
+    """
+    provisioner = provisioned_like_the_document(tmp_path)
+    documented = shape(documented_block("audio packages verify"))
+    actual = shape(provisioner.verify())
+
+    undocumented = sorted(set(actual) - set(documented) - VERIFY_CONDITIONAL)
+    assert not undocumented, (
+        f"audio packages verify emits fields §1.3 does not publish: {undocumented}"
+    )
+
+
+def test_the_verify_exemptions_are_all_still_reachable(tmp_path) -> None:
+    """An exemption for a key that can no longer appear is dead weight; make it prove itself."""
+    provisioner = provisioned_like_the_document(tmp_path)
+    reachable = set(shape(provisioner.verify()))
+    stale = sorted(VERIFY_CONDITIONAL - reachable)
+    assert not stale, (
+        f"VERIFY_CONDITIONAL exempts keys verify no longer emits: {stale} -- drop them"
+    )
+
+
+def test_the_comparison_can_fail() -> None:
+    """The floor this repository learned the hard way: an invariant that cannot fail is inert.
+
+    The punctuation floor spent four review passes asserting something about a stage that emits
+    no such output, and its test passed vacuously. So prove this one bites.
+    """
+    baseline = pkg.doctor(toolchain=StubToolchain())
+
+    drifted = dict(baseline)
+    drifted["warnings"] = []
+    assert set(shape(drifted)) - set(shape(baseline)) == {"warnings[]"}
+
+    retyped = json.loads(json.dumps(baseline))
+    retyped["root_exists"] = "true"
+    assert shape(retyped)["root_exists"] == "str"
+    assert shape(baseline)["root_exists"] == "bool"
+
+    renamed = json.loads(json.dumps(baseline))
+    renamed["external_tools"] = renamed.pop("tools")
+    assert "tools.ffmpeg.present" not in shape(renamed)

--- a/tests/test_shipped_commands_match_the_document.py
+++ b/tests/test_shipped_commands_match_the_document.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import pytest
 
+from audio_cli import environments as env
 from audio_cli import packages as pkg
 
 REPO = Path(__file__).resolve().parents[1]
@@ -188,14 +189,27 @@ VERIFY_CONDITIONAL = {
 def test_packages_verify_emits_no_field_the_document_does_not_publish(tmp_path) -> None:
     """The defect this catches: `verify` publishing a claim §1.3 never described.
 
-    It was there: `verify` emits the expected private-API hash beside the measured one, where
-    §1.3 published only the measured -- so `matches_expected: true` was unreproducible by eye.
-    """
-    provisioner = provisioned_like_the_document(tmp_path)
-    documented = shape(documented_block("audio packages verify"))
-    actual = shape(provisioner.verify())
+    It was there twice. `verify` emits the expected private-API hash beside the measured one,
+    where §1.3 published only the measured -- so `matches_expected: true` was unreproducible by
+    eye. And the guard's *passing* verdict adds `signature_ok` and `target`, which stayed
+    invisible here for as long as the only reachable path was the one that yields no verdict.
 
-    undocumented = sorted(set(actual) - set(documented) - VERIFY_CONDITIONAL)
+    So both guard paths are compared, unioned. §1.3 depicts a machine where the guard passes, and
+    a payload shape that only one fixture can reach is a payload shape nothing checks.
+    """
+    from test_packages import FakeToolchain  # sibling module, same rootdir
+
+    documented = shape(documented_block("audio packages verify"))
+    silent = provisioned_like_the_document(tmp_path)
+    emitted = set(shape(silent.verify()))
+
+    expected_hash = {guard["kind"]: guard
+                     for guard in env.environments()["mlx"].guards}["source_hash"]["sha256"]
+    answering = pkg.Provisioner(toolchain=FakeToolchain(private_api_hash=expected_hash),
+                                fetcher=silent.fetcher)
+    emitted |= set(shape(answering.verify()))
+
+    undocumented = sorted(emitted - set(documented) - VERIFY_CONDITIONAL)
     assert not undocumented, (
         f"audio packages verify emits fields §1.3 does not publish: {undocumented}"
     )

--- a/tests/test_shipped_commands_match_the_document.py
+++ b/tests/test_shipped_commands_match_the_document.py
@@ -178,6 +178,10 @@ VERIFY_CONDITIONAL = {
     # Absence is meaningful: set when the interpreter yields no verdict, so that
     # `matches_expected: null` cannot read as a passing check.
     "mlx_audio_private_api_error",
+    # Only a package spanning several repositories emits the plural, and §1.3's stack has none:
+    # `firered-asr2s` is the one, and it belongs to §3. The singular `revision` beside it *is*
+    # published, so the claim itself is documented -- this exempts its four-repo spelling.
+    "verified[].revisions[]",
 }
 
 

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,0 +1,129 @@
+"""Region building in `vad.py`, which had no test file at all.
+
+That absence is why the defect below survived: `vad_min_silence_ms` is a declared profile
+parameter, and nothing checked that it decided anything. Speech regions gate `voice-enhance`, so
+their boundaries reach the rendered audio -- on a 27.8 s fixture the fix moved a real render from
+6 regions to 10.
+
+Every test here stubs `probabilities`, so no ONNX model is loaded and nothing is downloaded. The
+detector's arithmetic is the thing under test; the model's judgement is not.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from audio_cli.profiles import PROFILES
+from audio_cli.vad import SileroOnnxVad
+
+SAMPLE_RATE = 16_000
+FRAME = SileroOnnxVad.frame_samples
+FRAME_MS = FRAME / SAMPLE_RATE * 1000  # 32 ms
+
+
+class StubVad(SileroOnnxVad):
+    """The real region builder over chosen probabilities. No model, no network."""
+
+    def __init__(self, probabilities: list[float]) -> None:
+        self._probabilities = np.asarray(probabilities, dtype=np.float32)
+
+    def probabilities(self, samples: np.ndarray, sample_rate: int) -> np.ndarray:
+        return self._probabilities
+
+
+def two_bursts(silence_frames: int, *, speech_frames: int = 20):
+    """Two confident speech runs separated by `silence_frames` of confident silence."""
+    return [0.9] * speech_frames + [0.0] * silence_frames + [0.9] * speech_frames
+
+
+def detect(probabilities: list[float], profile_name: str = "transcription"):
+    profile = PROFILES[profile_name]
+    samples = np.zeros(len(probabilities) * FRAME, dtype=np.float32)
+    return StubVad(probabilities).detect(
+        samples,
+        SAMPLE_RATE,
+        threshold=profile.vad_threshold,
+        exit_threshold=profile.vad_exit_threshold,
+        min_speech_ms=profile.vad_min_speech_ms,
+        min_silence_ms=profile.vad_min_silence_ms,
+        speech_pad_ms=profile.vad_speech_pad_ms,
+    )
+
+
+def test_min_silence_ms_is_what_decides_a_break() -> None:
+    """The defect this catches: a declared parameter that decided nothing.
+
+    Regions were merged on the gap left *after* padding, against a hard-coded 300 ms. Padding
+    shrinks every gap by `2 * speech_pad_ms`, so with the shipped 120 ms pad a 300 ms silence
+    reached the merge as 60 ms and was rejoined: the effective break was 540 ms while the profile
+    declared 300, and any value in between changed nothing at all.
+
+    The tolerance is two frames, and it is derived rather than fitted. Silence is only counted on
+    frames below `exit_threshold`, so the timer needs `ceil(min_silence / frame)` frames to
+    accumulate and then one further silent frame to be evaluated on:
+
+        ceil(4800 / 512) * 512 + 512 - 4800  =  5120 + 512 - 4800  =  832 samples  =  52 ms
+
+    So 352 ms is the grid, and it is bounded by two frames for any `min_silence_ms`. 540 ms was
+    not the grid -- it was two thresholds disagreeing, and it grew with `speech_pad_ms` rather
+    than with the frame size.
+    """
+    profile = PROFILES["transcription"]
+    declared = profile.vad_min_silence_ms
+    crossover_frames = next(
+        frames for frames in range(1, 60) if len(detect(two_bursts(frames))) == 2
+    )
+    crossover_ms = crossover_frames * FRAME_MS
+
+    quantization_ms = (
+        -(-profile.vad_min_silence_ms // FRAME_MS) * FRAME_MS  # ceil to the frame grid
+        + FRAME_MS
+        - profile.vad_min_silence_ms
+    )
+    assert crossover_ms > declared, "a gap at or under the declared silence must not split"
+    assert crossover_ms - declared <= quantization_ms, (
+        f"a break needs {crossover_ms:g} ms of silence where the profile declares {declared} ms, "
+        f"which overshoots by more than the {quantization_ms:g} ms the frame grid explains; "
+        f"something other than vad_min_silence_ms is deciding"
+    )
+    assert quantization_ms <= 2 * FRAME_MS, "the derivation above no longer holds"
+
+
+@pytest.mark.parametrize("silence_frames", [1, 4, 8, 11, 16, 32])
+def test_regions_stay_ordered_disjoint_and_non_empty(silence_frames: int) -> None:
+    """Padding may push two surviving regions together; it must not overlap or invert them."""
+    regions = detect(two_bursts(silence_frames))
+    assert regions, "confident speech produced no region"
+    for region in regions:
+        assert region.start < region.end, f"empty or inverted region {region}"
+    for earlier, later in zip(regions, regions[1:]):
+        assert earlier.end <= later.start, f"{earlier} overlaps {later}"
+
+
+def test_a_gap_far_below_the_threshold_is_one_region() -> None:
+    """The merge still has to do its job: a short pause is not a break."""
+    assert len(detect(two_bursts(2))) == 1
+
+
+def test_regions_never_leave_the_signal() -> None:
+    """Padding is clamped, so a region cannot start before zero or end past the last sample."""
+    probabilities = [0.9] * 6  # speech from the first frame to the last
+    regions = detect(probabilities)
+    duration = len(probabilities) * FRAME / SAMPLE_RATE
+    assert regions
+    assert regions[0].start >= 0.0
+    assert regions[-1].end <= duration
+
+
+def test_probabilities_are_reported_over_the_region_they_describe() -> None:
+    """`mean_probability` has to come from the region's own frames, not the whole signal."""
+    quiet, loud = 0.0, 0.9
+    probabilities = [loud] * 20 + [quiet] * 32 + [loud] * 20
+    regions = detect(probabilities)
+    assert len(regions) == 2
+    for region in regions:
+        assert region.peak_probability == pytest.approx(loud, abs=1e-6)
+        assert region.mean_probability > 0.5, (
+            "a speech region averaging in the silence around it is reporting the wrong span"
+        )


### PR DESCRIPTION
Fifteen defects in the shipped CLI, all fixed, each with a test demonstrated to fail without it.
None were found by running the suite — the suite passed throughout. They were found by comparing
what the code *claims* against what it *does*, which is the process rule this repository is
organized around, and by exercising for real the paths that only fakes had ever covered.

Ten are in the provisioning layer that landed in #15. Five are in the enhancement engine, where
coverage was inverted against risk: `media.py` (416 lines) and `vad.py` (245) had **no test file at
all**, while `pipeline.py` (845) had three tests.

## The five shapes

Grouped by the kind of mistake rather than by file, because the shapes are the transferable part
and every one of them survived review by looking finished.

### A claim nobody earned

**1.** `pull` recorded `digest_verified: true` for every Hub package and hashed none of them — the
manifest carries no `sha256` for a Hub source, so there was nothing to hash *against*. `verify`
then reported `digest: "ok"`, which for those packages meant only that a path existed, and the
honest `"unverified"` branch was unreachable for anything this code pulls. A default that reads
like a measurement is what CLAUDE.md prohibits outright, in the field that most needs to be
trustworthy.

Fixed by claiming what is true rather than confessing what is not: Hub packages publish the pinned
`revision`, `url` packages keep the `digest` they genuinely earn, and the two are told apart by
which key is present.

**15.** A Swift build whose product could not launch reported `product_runs: false` and exited 0
with an empty `warnings`, while `verify` said `failed: []` and the environment read `ok`. The cause
underneath: `swift_product_runs` ran `swift run … fluidaudio` while `Package.swift` at the pinned
commit declares `.executable(name: "fluidaudiocli")`, so the check answered *no executable product
named 'fluidaudio'* on a good build and **could never return true** — making `product_runs: true`,
which §1.3 publishes, unreachable. The name is pinned in the manifest beside the commit now, and
`pull` raises `package_build_unusable` at exit 3 with the entry left `pulling`.

### A flag that parses is not a flag that works

**2.** `--repair` was declared, documented in §4.8, and named in four `fix` strings `verify` emits
— and read by no code at all. For a `url` package a plain re-pull happened to repair it; for a Hub
package `snapshot_download` returns a present-but-corrupt snapshot untouched without
`force_download`, so the documented remediation silently did nothing on exactly the multi-gigabyte
packages where corruption costs most.

**5.** `--want` was accepted and ignored, the precise pattern TRANSCRIBE_CONTRACT.md §4.6
condemns. Refused now until the planner lands (#12).

**6.** `--stack` beside named packages silently dropped the stack.

A mutation scan then neutralized all 20 `repair`/`force`/`dry_run`/`stack`/`allow_*` branches
across the three command surfaces and ran the suite against each. **Six were invisible**,
including `--dry-run` not reaching `purge` — where a dropped argument reclaims what a caller only
asked about — and `enhance --force` unasserted on both its targets, which is how **8** (`inspect
--report` hard-coding `force=False`) survived to become a bug at all.

### A parameter that decided nothing

**11.** `vad_min_silence_ms` declared 300 ms and decided nothing across a 240 ms band. Regions
split during detection at `min_silence`, were padded by `speech_pad_ms` each side, then merged
again if the gap *surviving padding* fell under a hard-coded 300 ms. Padding shrinks every gap by
twice the pad, so a 300 ms silence arrived at the merge as 60 ms and was rejoined. Measured against
the pre-fix file: **a break needed 544 ms**. Speech regions gate `voice-enhance`, so this reached
the render — the 27.8 s fixture moves from 6 regions to 10. Both profiles go to **version 4**.

Two thresholds answering one question can only disagree, so there is one now: the merge reads the
raw gap against `min_silence` itself. What remains is the 32 ms frame grid, and the test derives
that bound rather than asserting the number.

### A bound the media does not have

**14.** `resample_poly` returns `ceil(n·up/down)`, so 1332160 samples at 48 kHz became 444054 at
16 kHz where the exact figure is 444053.333 — and a region running to the end was published ending
at **27.753375 s in a 27.753333 s file**. It broke a second guarantee downstream: the treatment
clamp pulled that end back, so `end_extension_ms` went to **−0.042**, treatment ending *before* the
last detected sample, where the placement rule is full engagement at the first and last of them.

Found by sweeping every resolved boundary in every report generated from the local fixtures against
the invariants the report itself implies. That is how a 42 µs defect becomes visible.

### The rest

**3.** `pull` re-materialized already-ready packages and flipped a healthy one to `pulling` first,
so an interrupt during a pointless re-pull downgraded a working install. **4.** A toolchain-blocked
package sank an entire stack pull: `--stack qwen-1.7b` with no Swift exited 3 having provisioned
nothing, not even the mlx weights it needed — contradicting §0's promise that an absent `swift`
blocks "only the packages that need it". **7.** `_locations` used a substring test where it meant a
prefix test. **9.** `remove` deleted files before validating the whole list, so one bad name
destroyed a good package's bytes while the registry kept calling it ready — the mirror of the rule
`pulling` exists to enforce. **12.** `mkstemp`'s 0600 rode through `os.replace` onto published
reports, so an 0600 report sat beside its own 0644 wav. **13.** A 50 ms clip at −50 dBFS was refused
as "silent"; integrated loudness is gated in 400 ms blocks and the true peak is what separates the
cases — `input_i = -inf` with `input_tp = -39.26` versus `-inf` for both. The boundary is exact:
380 ms unmeasurable, 400 ms measures −50.35.

Fixing **4** made a new state reachable — an environment provisioned but unusable. `verify` called
it `ok`; it reports `blocked` now, a fourth verdict registered in VOCABULARY.md. `doctor`'s
`state: "ready"` deliberately stays: a registry-state field reports the registry, a verdict field
reports usability, and only the verdict was lying.

## Tests that can fail

**10.** `test_verify_reports_a_drifted_environment_and_repairs_it` did not test the repair. Its
last assertion used a *second, undrifted* toolchain, which reports `ok` with or without the flag,
so `verify`'s `if drift and repair` branch never executed. The cause was the double, not the test:
`FakeToolchain` could not stop being drifted, making a repaired environment unrepresentable.

Both doubles are now held to one rule, learned twice: **a double must be able to represent the
state a repair produces.** Two more payload shapes turned out to be unreachable rather than
untested — the private-API guard's *passing* verdict, and a multi-repo package's repair, which
passes `force` through separate code from the single-repo path.

`tests/test_shipped_commands_match_the_document.py` is new and is why three of these were found.
`doctor`, `packages list`, and `packages verify` ship and are published in
TRANSCRIBE_HAPPY_PATH.md, and nothing compared them — `test_spec_docs.py` checks the documents
against each other and `test_packages.py` checked each command against its own output. All three
had drifted. It is also the pattern the `transcribe` acceptance criterion needs later: a plan's
`sample_output` key set against a real run's.

## Exercised against reality, not fakes

| Path | Evidence |
| --- | --- |
| `uv venv` + hash-pinned lock | all four environments built, each `ok` against its own lock |
| the four-environment partition | `torch-firered` on transformers 5.1.0, `torch-vibevoice` on 4.57.6 — installed, not inferred |
| Hub download, revision cached | detected, not re-fetched, correctly not this root's to delete |
| Hub download, forced fresh | **1,101,647,163 bytes measured on the wire** for a 1,010,773,761-byte package |
| single-file fetch + digest | silero-vad, 2,327,524 bytes, verified against the manifest |
| Swift clone, build, launch | Swift 6.3.3; `product_runs: true` after the emitted repair |
| `mlx_audio` private-API guard | measured hash matches the pin, `signature_ok: true` |
| render invariants | source byte-identical after a run, deterministic across repeats, `--force` preserves render *and* report when a run fails partway |
| stage scoping | skipping all five stages is a true no-op (1.19e-07, float32 round-trip) |
| video path | video payload bit-for-bit identical, 300 frames, 1920×1080 |
| provenance | `original_sha256` matches the real input; the report's `output.sha256` matches the file; `final_peak_validation` matches an independent measurement; −23 LUFS hit to 0.01 LU |
| documented refusal | with `program-loudness` skipped, a clipping signal fails at exit 2 naming the predicted peak |
| teardown | reference counting, pre-existing revisions protected, `--dry-run` inert |

## Four suspicions that were wrong

Recorded because the checking is the point, not the hit rate — and because each would have been a
bad change.

- **`timeline_preserved: true` on a 44 ms difference.** Decoded, both files are exactly 1332160
  samples with a 2-sample lag; the 44 ms is m4a container padding. The claim is honest.
- **`channel_max_correction_db: 6.0` applying −6 and +6.** Measured 12.041 dB in, 0.041 dB out — 12
  dB of relative correction. But nothing declares the field a bound on the *difference*, and both
  gains are printed beside it. Loose naming, not a defect.
- **A 40 ms constant shadowing `region_fade_ms`.** Different concept sharing a value.
- **`voice-enhance` appearing not to expand to acoustic boundaries.** On a ground-truth fixture,
  `environment-denoise` resolved activity to 4.92 and `voice-enhance` to 4.44, expanding by 0 ms.
  Measured, the utterance tail sits at **−53.4 dBFS against speech at −37.7** — 16 dB down, where
  `voice_boundary_speech_margin_db` declares 12. Both stages are correct on what each sees. I wrote
  the fix, found it moved the threshold 0.75 dB and changed no outcome, and **reverted it** rather
  than shifting every render on a misreading.

## Verification

- `uv run --extra dev pytest` — **181 passed**
- two independent probe suites, written before any fix and kept outside the repository so they could
  not be tuned to — **27/27** and **14/14**
- every fix perturbed to confirm its test goes red, then restored

## One decision left open

TRANSCRIBE_CONTRACT.md declares `failed[]` elements as `(package, check, expected, actual)`; the
code emits `{package, code, detail, fix}`. The contract's version is machine-comparable and the
code's is prose, so this is a real decision rather than drift, and `transcribe`'s twelve refusals
will be built against that table. The document-comparison test abstains on it rather than
ratifying either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)