### PR TITLE
Correct transcribe phase zero contract

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -319,22 +319,28 @@ registry's own `state`, which is a different fact — see VOCABULARY.md for both
 
 ## Running a stage in another environment
 
-The recorded evidence used **strictly sequential fresh subprocesses** — that is what
-`run_interview_pipeline.py` measured and what the per-stage memory figures assume. So:
+The recorded evidence used **strictly sequential environment processes** — that is what
+`run_interview_pipeline.py` measured for the composed stacks and what the process-level memory
+figures assume. So:
 
-- One subprocess per stage, spawned as `<root>/envs/<env>/bin/python <stage script> <request>
-  <result>`, where the stage script is a file inside the installed wheel, passed by absolute
-  path. `audio_cli` is *not* installed into provisioned environments: it would drag
-  onnxruntime and a conflicting numpy into each one.
+- Qwen, VibeVoice, and add-on stages use one subprocess per executable stage, spawned as
+  `<root>/envs/<env>/bin/python <stage script> <request> <result>`, where the stage script is a
+  file inside the installed wheel, passed by absolute path. FireRed is one deliberate exception:
+  its single `torch-firered` stage script loads VAD, optional LID, ASR, and punctuator models
+  co-resident, matching `model_tests/benchmark/run_firered.py:395-426` and the recorded artifacts.
+  Splitting those roles would be a new implementation with no supporting measurement.
+- `audio_cli` is *not* installed into provisioned environments: it would drag onnxruntime and a
+  conflicting numpy into each one.
 - Request in, result out, both as JSON files; progress on stderr; exit code as the signal.
-- Residency is enforced by process exit rather than by discipline. "No two model stages
-  resident at once" is a consequence of the transport, not a rule someone must remember.
+- Residency between environment processes is enforced by process exit rather than by discipline.
+  No two environment processes are resident together; models owned by one process may be, as
+  FireRed's measured 12.26 GiB LID-on and 9.16 GiB LID-off peaks demonstrate.
 
 This also makes the adapter-normalization floor structural. A model-specific object cannot
-cross a process boundary, so the stage script must serialize normalized output — the floor is
-satisfied by construction instead of by review. A persistent worker would give that up and
-would be outside what was measured; if one is ever needed for load time, it needs its own
-evidence.
+cross an environment-process boundary, so the stage script must serialize normalized output —
+the floor is satisfied by construction instead of by review. A persistent worker spanning
+requests would give that up and would be outside what was measured; if one is ever needed for
+load time, it needs its own evidence.
 
 `swift` has no interpreter, so its stage invokes the built product directly. That asymmetry is
 contained in one place: the transport chooses an executable per environment, and every

--- a/TRANSCRIBE_CONTRACT.md
+++ b/TRANSCRIBE_CONTRACT.md
@@ -56,6 +56,7 @@ field not listed for its code, or missing one that is, is a defect:
 | `input_required` | 2 | `field`, `note` |
 | `capability_unknown` | 2 | `field`, `provided`, `available_on_stack`, `did_you_mean` when a near name exists |
 | `option_unsupported_on_stack` | 2 | `field`, `provided`, `allowed` (empty), `stacks_accepting` |
+| `option_value_unsupported` | 2 | `field`, `provided`, `allowed`, `did_you_mean` when a near value exists |
 | `capability_unsatisfiable_on_stack` | 2 | `capability`, `allowed` (non-empty), `available_on_stack` |
 | `capability_unsupported` | 2 | `capability`, `allowed` (empty), `reason` |
 | `pin_conflicts_with_native_capability` | 2 | `field`, `provided`, `allowed`, `capability` |
@@ -105,6 +106,18 @@ real second configuration, not a default: the model still emits a language label
 no hint, and the two Qwen sizes disagreed with each other on the same recording when
 run that way, which is an argument for stating the language you know and against
 trusting the label you get back.
+
+The accepted `--language` values are case-insensitive but are echoed with this exact spelling:
+`Chinese`, `English`, `Cantonese`, `Arabic`, `German`, `French`, `Spanish`, `Portuguese`,
+`Indonesian`, `Italian`, `Korean`, `Russian`, `Thai`, `Vietnamese`, `Japanese`, `Turkish`,
+`Hindi`, `Malay`, `Dutch`, `Swedish`, `Danish`, `Finnish`, `Polish`, `Czech`, `Filipino`,
+`Persian`, `Greek`, `Romanian`, `Hungarian`, and `Macedonian`. Those 30 names are the
+`support_languages` arrays in the pinned
+[`Qwen3-ASR-1.7B-8bit` config](https://huggingface.co/mlx-community/Qwen3-ASR-1.7B-8bit/blob/a8379a2e2f9e313c9292cdf1af4055ab56d50d55/config.json)
+and [`Qwen3-ASR-0.6B-8bit` config](https://huggingface.co/mlx-community/Qwen3-ASR-0.6B-8bit/blob/89e96d92ba34aca20b3e29fb10cc284097d1219f/config.json),
+not a vocabulary invented by this CLI. FireRed accepts no language input; its `lid` output is
+the 115 labels after the five special tokens in the pinned
+[`FireRedLID` dictionary](https://huggingface.co/FireRedTeam/FireRedLID/blob/1bb4d285c8456429385d9c0810300df4297bc11b/dict.txt).
 
 ## Two questions, two commands
 
@@ -181,12 +194,12 @@ yet and `satisfaction` is defined only for a requested capability:
     "segment_timestamps": {"availability": "native",
                            "note": "Sentence extents from the punctuation stage. Unmeasured against labels."},
     "lid": {"availability": "native",
-            "note": "One label per VAD region, copied onto every sentence inside it, so per-sentence variation would be fabricated. Adds 78 s on a 139-second sample — 162 s with the stage against 84 s without — and about 16 s on this input. Its weights are fetched only when this capability is requested and their size is unrecorded."},
+            "note": "One label per VAD region, copied onto every sentence inside it, so per-sentence variation would be fabricated. On the same 139.284-second probe, LID on measured 162.09 s and 12.26 GiB peak RSS versus 84.24 s and 9.16 GiB with LID off. Its weights are fetched only when this capability is requested."},
     "diarization": {"availability": "requires_add_on",
-                    "note": "Adds FluidAudio, which needs a Swift toolchain and a second environment: 15 s and 0.55 GiB peak on a 30-minute sample, and that same run also serves overlapped_speech. Produces speaker labels on the text and the turn intervals together, mapped onto the transcript by an exact partition of the timeline so no span is transcribed twice and no gap is invented. Measured 95.42% participant-interval F1 on a 30-minute interview but matched only 3 of 75 annotated speaker changes on a dense two-speaker conversation — strong on long turns, unsuitable where turns are short or overlapping. RSS excludes memory held by system Core ML services."
+                    "note": "Adds FluidAudio, which needs a Swift toolchain and a second environment: 15 s and 0.55 GiB peak on a 30-minute sample. Produces speaker labels on the text and the turn intervals together, mapped onto the transcript by an exact partition of the timeline so no span is transcribed twice and no gap is invented. The published 95.42% participant-interval F1 and 3-of-75 speaker-change figures came from a run with a two-speaker prior and overlap detection enabled; the shipped default supplies no speaker-count prior and enables overlap detection only when overlapped_speech is requested, so its quality is unmeasured. RSS excludes memory held by system Core ML services."
                     },
     "overlapped_speech": {"availability": "requires_add_on",
-                          "note": "Comes out of the same FluidAudio run as diarization, so asking for both costs one stage. Unmeasured. Without it nothing in the plan detects overlap, so an empty abstention ledger means undetected rather than absent."},
+                          "note": "Enables FluidAudio's overlapping-segments mode in the same stage as diarization. The recorded 95.42% participant-interval F1 and downstream 33.56% MER used this mode plus a two-speaker prior; the shipped no-prior configuration is unmeasured. Without this request nothing in the plan detects overlap, so an empty abstention ledger means undetected rather than absent."},
     "token_lid": {"availability": "impossible", "reason": "no_backend_declares",
                   "note": "Named only so a request fails loudly. Code-switching support does not imply per-token labels, and no backend here produces them."}
   },
@@ -197,15 +210,16 @@ yet and `satisfaction` is defined only for a requested capability:
 `processing` and `failure_recovery` are why `--input` is required rather than optional.
 Neither is derivable from the stack: the unit a stack works in is a stack property, but
 how many units *this* file yields, what it will cost, and whether a failure is survivable
-are properties of the pair. `unit_count_known_at_plan_time: false` is the honest answer
-wherever the partition depends on content the plan has not decoded — VAD regions here,
-diarized turns on a Qwen plan that requests `diarization` — and it is stated
-rather than guessed, because a fabricated count is worse than an absent one.
+are properties of the pair. The fixed structural field is `unit_count: null` wherever the
+partition depends on content the plan has not decoded — VAD regions here, diarized turns on a
+Qwen plan that requests `diarization` — because a fabricated count is worse than an explicit
+unknown.
 
 `failure_recovery` varies by stack and is the field to read before committing to a long
-file. It is `per_unit` here and on Qwen; it is **`none` on `vibevoice`**, which is handed
-whole media in a single `generate` call, so there is no partition to salvage and a failure
-at minute forty of a forty-one-minute run yields nothing. See §5.1.
+file. It is `per_unit` here and on Qwen; it is **`prefix_only` on `vibevoice`**, which is handed
+whole media in a single `generate` call. A generation-cap truncation can salvage every complete
+segment before the cut and resume from that prefix watermark, while a model-load failure still
+leaves nothing. See §5.1.
 
 Everything in that document is there because a caller acts on it, and almost none of it is
 structured. Three enums carry the decisions a program branches on — `availability`,
@@ -300,7 +314,7 @@ floor the moment a consumer read it as measured. Real metadata that the plan
 genuinely has — duration, path — is populated rather than stubbed.
 
 Enum-valued fields are the one exception: they show one legal member rather than
-`null`, so a consumer can see the field is categorical. So `"reason": "overlap"` is
+`null`, so a consumer can see the field is categorical. So `"reason": "raw_fragment"` is
 shape, while `"text": null` is content withheld. Free-text and numeric fields are
 always `null`. One member is not the member set, so the sample is not where a
 consumer learns it: the plan warns when nothing in it can detect overlap, which is the
@@ -362,8 +376,8 @@ Exits 0 whether or not anything is provisioned:
                    "environment": "swift",
                    "config": {"preset": "quality", "step_ratio": 0.1,
                               "min_segment_duration": 0.0, "output": "regular",
-                              "threshold": 0.6, "num_speakers": 2},
-                   "config_note": "every cited diarization measurement used a known two-speaker prior; num_speakers must be supplied or the measured_limit figures do not apply",
+                              "threshold": 0.6},
+                   "config_note": "the shipped default supplies no speaker-count prior and enables overlapping_segments only when overlapped_speech is requested; the cited quality figures used both --num-speakers 2 and --overlapping-segments, so they do not measure this request",
                    "selected_by": "add_on_required_by:diarization"}
   },
   "execution": {
@@ -373,25 +387,26 @@ Exits 0 whether or not anything is provisioned:
   },
   "capabilities": {
     "diarization": {"satisfaction": "derived", "backend": "fluidaudio",
-                    "evidence": {"interface": "verified", "quality": "measured"},
-                    "note": "Anonymous labels reconciled sample-exactly onto the ASR text, plus the diarizer's turn intervals. This preset matched 3 of 75 annotated speaker changes on a dense conversation and is not validated for rapid backchannels, interruptions, or dense overlap."
+                    "evidence": {"interface": "verified", "quality": "unmeasured"},
+                    "note": "Anonymous labels are reconciled sample-exactly onto the ASR text, plus the diarizer's turn intervals. The shipped no-prior, overlap-off configuration is unmeasured; the 3-of-75 speaker-change result used a two-speaker prior with overlap detection enabled and does not apply to this request."
                     }
   },
   "packages": [
     {"package": "qwen3-asr-1.7b-8bit", "environment": "mlx", "kind": "weights",
-     "bytes": 2463307541, "provisioned": false},
+     "bytes": 2467859030, "provisioned": false},
     {"package": "fluidaudio", "environment": "swift", "kind": "toolchain",
      "requires_tool": ["swift"], "bytes": null, "provisioned": false},
     {"package": "speaker-diarization-coreml", "environment": "swift", "kind": "weights",
      "bytes": null, "provisioned": false}
   ],
-  "total_known_download_bytes": 2463307541,
+  "total_known_download_bytes": 2467859030,
   "unsized_packages": ["fluidaudio", "speaker-diarization-coreml"],
   "warnings": [],
   "sample_output": {
     "sample": true,
     "note": "shape only; values are placeholders and cardinality is unknown until run",
     "schema_version": 1,
+    "complete": true,
     "source": {"path": "meeting.m4a", "duration_seconds": 1794.2, "timebase": "seconds"},
     "segments": [
       {"segment_id": "seg_0", "text": null, "speaker": null}
@@ -400,7 +415,7 @@ Exits 0 whether or not anything is provisioned:
       {"turn_id": "turn_0", "speaker": null, "start": null, "end": null}
     ],
     "abstentions": [
-      {"abstention_id": "ab_0", "reason": "overlap", "start": null, "end": null}
+      {"abstention_id": "ab_0", "reason": "raw_fragment", "start": null, "end": null}
     ],
     "provenance": "<stack, outcomes, observed, and the executed plan; elided in print>"
   }
@@ -478,11 +493,11 @@ Exit 3. Nothing computed, nothing downloaded, stderr:
 {
   "code": "packages_not_provisioned",
   "missing": [
-    {"package": "qwen3-asr-1.7b-8bit", "kind": "weights", "bytes": 2463307541},
+    {"package": "qwen3-asr-1.7b-8bit", "kind": "weights", "bytes": 2467859030},
     {"package": "fluidaudio", "kind": "toolchain", "requires_tool": ["swift"], "bytes": null},
     {"package": "speaker-diarization-coreml", "kind": "weights", "bytes": null}
   ],
-  "total_known_download_bytes": 2463307541,
+  "total_known_download_bytes": 2467859030,
   "unsized_packages": ["fluidaudio", "speaker-diarization-coreml"],
   "fix": "audio packages pull --stack qwen-1.7b"
 }
@@ -545,7 +560,8 @@ the one package that auto-fetches:
                            "speech_pad_ms": 120},
                 "selected_by": "add_on_required_by:vad"},
     "aligner": {"backend": "qwen3-forcedaligner", "environment": "mlx",
-                "config": {"scope": "all_segments"},
+                "config": {"scope": "all_segments",
+                           "language_rule": "Chinese when text matches [一-鿿], otherwise English; the ASR --language hint is never forwarded"},
                 "selected_by": "add_on_required_by:word_timestamps"}
   },
   "capabilities": {
@@ -645,7 +661,8 @@ fields that differ from §1.1** — the envelope, `packages`, and
                 "determinism_note": "acoustic tokenizer samples a Gaussian latent; fixed seed required",
                 "selected_by": "stack"},
     "aligner": {"backend": "qwen3-forcedaligner", "environment": "mlx",
-                "config": {"scope": "all_segments"},
+                "config": {"scope": "all_segments",
+                           "language_rule": "Chinese when text matches [一-鿿], otherwise English; the ASR --language hint is never forwarded"},
                 "selected_by": "add_on_required_by:word_timestamps"}
   },
   "capabilities": {
@@ -670,6 +687,16 @@ fields that differ from §1.1** — the envelope, `packages`, and
   ]
 }
 ```
+
+The aligner rule is executable provenance, not a language-quality claim: the recorded probe
+selects `Chinese` when its text regex sees a CJK ideograph and `English` otherwise
+(`model_tests/benchmark/run_mlx_forced_aligner_probe.py:55,94`). It does not forward Qwen's
+`Cantonese` hint. The pinned aligner implementation branches only for Japanese and Korean;
+Chinese, Cantonese, English, and every other value use `tokenize_space_lang`, whose own CJK
+splitter handles ideographs (`qwen3_forced_aligner.py:129-145,236-247`). There is therefore no
+Chinese-only path and no Cantonese-specific tokenization failure. A future adapter declares
+this rule because it is the configuration the recorded probe actually ran, not because the
+pinned source proves it is better than forwarding the ASR hint.
 
 ```bash
 audio packages pull --stack vibevoice
@@ -751,6 +778,12 @@ from inside the stack rather than as an add-on. Abridged to `roles` and `executi
                    "config": {"batch_size": 4},
                    "selected_by": "floor:punctuated_sentence_segmented_text",
                    "recases_text": true}
+  },
+  "execution": {
+    "stage_order": ["decode", "vad", "asr", "punctuator"],
+    "residency": "one_environment_process_at_a_time",
+    "environments_spanned": ["torch-firered"],
+    "note": "FireRed runs one process with VAD, ASR and punctuator co-resident; requesting lid loads that model into the same process. The measured LID-off peak is 9830449152 bytes (9.16 GiB), not a maximum of imaginary per-role processes."
   }
 }
 ```
@@ -974,6 +1007,15 @@ flag that does nothing — which would let a caller believe it had constrained a
 it had not touched.
 
 ```bash
+audio transcribe plan --input meeting.m4a --stack qwen-1.7b --language EN
+```
+
+Exit 2, `code: "option_value_unsupported"`, `field: "--language"`, `provided: "EN"`,
+`allowed` containing the exact 30-name Qwen vocabulary, and `did_you_mean: "English"`.
+This is distinct from `option_unsupported_on_stack`: Qwen accepts the option, but not that
+value. `english` is accepted case-insensitively and normalized to `English` in the plan.
+
+```bash
 audio transcribe plan --input meeting.m4a --stack firered --want token_lid
 ```
 
@@ -1122,10 +1164,12 @@ audio export --input meeting.partial.json --input meeting.rest.json \
   --format srt -o meeting.srt
 ```
 
-**On `vibevoice` none of this applies.** `failure_recovery.partial_results` is `none`
-there, because the stack is handed whole media in one call and has no partition to
-salvage. That is the sharpest reason `capabilities` reports the field: on a long file the
-most likely failure — memory — lands on the one stack that cannot resume.
+**On `vibevoice`, recovery is `prefix_only`.** The upstream parser yields no structured result
+when generation stops inside an unterminated segment, so the adapter must parse the raw output
+and retain every complete segment before the cut. That prefix is a conforming result with
+`complete: false`, a coverage watermark at its end, and a `--range` fix for the remainder.
+This does not turn every failure into a partial result: an OOM at model load has decoded no
+prefix, writes no result, and remains exit 1.
 
 ## 6. Teardown
 

--- a/TRANSCRIBE_DESIGN_HANDOFF.md
+++ b/TRANSCRIBE_DESIGN_HANDOFF.md
@@ -75,9 +75,10 @@ you recognise a settled question when you meet one.
    capabilities, whether the planner is a pure function over a stack table — is yours.
    `src/audio_cli/` currently has no abstraction for this; `vad.py` is the only backend-shaped
    file and it predates the vocabulary.
-2. **Stage orchestration.** Stages run strictly sequentially with one model resident at a
-   time. The transport is settled — one fresh subprocess per stage against the environment's
-   own interpreter, JSON in and JSON out, residency enforced by process exit
+2. **Stage orchestration.** Environment processes run strictly sequentially. The transport is
+   settled — one fresh subprocess per executable stage against the environment's own interpreter,
+   except that FireRed's single process owns its co-resident VAD, optional LID, ASR, and
+   punctuator models; JSON in and JSON out, inter-environment residency enforced by process exit
    ([ENVIRONMENTS.md](ENVIRONMENTS.md)) — which also makes the adapter-normalization floor
    structural, since no model object can cross a process boundary. What remains is the
    orchestration above it: stage order, the observed-cost accounting, and the ledger.
@@ -124,10 +125,12 @@ you recognise a settled question when you meet one.
   all, while FireRed cannot leave PyTorch because `mlx-audio` has no punctuator and
   punctuation is a floor. See [ENVIRONMENTS.md](ENVIRONMENTS.md); issue
   [#11](https://github.com/fyang0507/audio-processing-cli/issues/11).
-- **`vibevoice` cannot resume.** It is handed whole media in a single `generate` call, so a
-  failure at minute forty of a forty-one-minute run yields nothing. It is also the stack most
-  likely to fail, having measured 20.28 GiB live MPS on thirty minutes and OOMed under a
-  strict 16 GiB cap. Do not design a recovery story that quietly assumes partitioning.
+- **`vibevoice` recovery is prefix-only.** It is handed whole media in a single `generate` call,
+  but when a generation cap truncates raw output the adapter can retain every complete parsed
+  segment before the cut and resume from that watermark. An OOM at model load still yields
+  nothing. It remains the stack most likely to fail, having measured 20.28 GiB live MPS on
+  thirty minutes and OOMed under a strict 16 GiB cap. Do not describe prefix salvage as
+  partitioned execution.
 - **A long Qwen run truncates silently today.** The recorded runner carries a global
   generation budget and stops between turns when it runs out. Every recorded run finished, but
   at the recorded token rate the budget exhausts near **1.6 hours** of comparable audio. Exit 4

--- a/TRANSCRIBE_HAPPY_PATH.md
+++ b/TRANSCRIBE_HAPPY_PATH.md
@@ -175,21 +175,21 @@ audio transcribe capabilities --stack qwen-1.7b --input meeting.m4a
   },
   "capabilities": {
     "languages": {"availability": "native",
-                  "note": "Advertises 30 language labels and has no dialect selector; only Mandarin, English and Cantonese have actually been run here. The one accuracy figure is Cantonese at 33.56% mixed-token error on a 30-minute interview. Accepts a --language hint, which every recorded figure above was produced with; the label it returns without one is not a detector to route on."
+                  "note": "Accepts the 30 names published by both pinned Qwen config.json support_languages arrays, case-insensitively and with canonical spelling; has no dialect selector. Only Mandarin, English and Cantonese have actually been run here. The one accuracy figure is Cantonese at 33.56% mixed-token error on a 30-minute interview, using diarization with --num-speakers 2 and --overlapping-segments. The label it returns without a hint is not a detector to route on."
                   },
     "verbatim": {"availability": "native",
                  "note": "Does not clean disfluencies, but drops every spoken \"uh\" and sometimes fuses the neighbouring words. Filler recall is unmeasured on every stack."
                  },
     "diarization": {"availability": "requires_add_on",
-                    "note": "Adds FluidAudio, which needs a Swift toolchain and a second environment: 15 s and 0.55 GiB peak on a 30-minute sample, and that same run also serves overlapped_speech. Produces speaker labels on the text and the turn intervals together, mapped onto the transcript by an exact partition of the timeline so no span is transcribed twice and no gap is invented. Measured 95.42% participant-interval F1 on a 30-minute interview but matched only 3 of 75 annotated speaker changes on a dense two-speaker conversation — strong on long turns, unsuitable where turns are short or overlapping. RSS excludes memory held by system Core ML services."
+                    "note": "Adds FluidAudio, which needs a Swift toolchain and a second environment: 15 s and 0.55 GiB peak on a 30-minute sample. Produces speaker labels on the text and the turn intervals together, mapped onto the transcript by an exact partition of the timeline so no span is transcribed twice and no gap is invented. The published 95.42% participant-interval F1 and 3-of-75 speaker-change figures used --num-speakers 2 plus --overlapping-segments; the shipped default supplies no speaker-count prior and enables overlap detection only when overlapped_speech is requested, so its quality is unmeasured. RSS excludes memory held by system Core ML services."
                     },
     "overlapped_speech": {"availability": "requires_add_on",
-                          "note": "Comes out of the same FluidAudio run as diarization, so asking for both costs one stage. Unmeasured. Without it nothing in the plan detects overlap, so an empty abstention ledger means undetected rather than absent."},
+                          "note": "Enables FluidAudio's overlapping-segments mode in the same stage as diarization. The recorded 95.42% participant-interval F1 and downstream 33.56% MER used this mode plus a two-speaker prior; the shipped no-prior configuration is unmeasured. Without this request nothing in the plan detects overlap, so an empty abstention ledger means undetected rather than absent."},
     "vad": {"availability": "requires_add_on",
             "note": "Adds Silero, a hash-pinned file that fetches itself, so it never returns exit 3: 0.4 s and 0.11 GiB peak on a 150-second sample, about 5 s on this input. Measured 0.8505 frame-level F1 at 0.7655 precision and 0.9567 recall, so the gate over-includes — it bounds activity, not speakers."
             },
     "word_timestamps": {"availability": "requires_add_on",
-                        "note": "Adds Qwen3-ForcedAligner in the torch environment, so this request spans three: 4.6 s of alignment on a 139-second sample excluding model load, about a minute on this input. Never scored against hand-labelled boundaries, and neither is FireRed's native timing, so switching stacks for accuracy would trade one unmeasured number for another. Absent on any segment with no speech to align."},
+                        "note": "Adds Qwen3-ForcedAligner beside ASR in the existing mlx environment, so with FluidAudio this request spans two environments: 4.6 s of alignment on a 139-second sample excluding model load, about a minute on this input. Never scored against hand-labelled boundaries, and neither is FireRed's native timing, so switching stacks for accuracy would trade one unmeasured number for another. Absent on any segment with no speech to align."},
     "segment_timestamps": {"availability": "impossible", "reason": "no_native_segment_extents",
                            "note": "This stack emits no segment extents. The chunk boundaries it works in are not speech timing and are never published as any."},
     "lid": {"availability": "impossible", "reason": "no_backend_declares_on_stack",
@@ -234,8 +234,8 @@ audio transcribe plan --input meeting.m4a \
                    "environment": "swift",
                    "config": {"preset": "quality", "step_ratio": 0.1,
                               "min_segment_duration": 0.0, "output": "regular",
-                              "threshold": 0.6, "num_speakers": 2},
-                   "config_note": "every cited diarization measurement used a known two-speaker prior; num_speakers must be supplied or the measured_limit figures do not apply",
+                              "threshold": 0.6},
+                   "config_note": "the shipped default supplies no speaker-count prior and enables overlapping_segments only when overlapped_speech is requested; the cited quality figures used both --num-speakers 2 and --overlapping-segments, so they do not measure this request",
                    "selected_by": "add_on_required_by:diarization"},
     "asr":        {"backend": "qwen3-asr-1.7b-8bit", "environment": "mlx",
                    "revision": "a8379a2e2f9e313c9292cdf1af4055ab56d50d55",
@@ -248,7 +248,8 @@ audio transcribe plan --input meeting.m4a \
                    "determinism_tolerance_ms": 0.0,
                    "determinism_basis": "argmax decode; back-to-back calls in one process produced byte-identical text, cross-process repetition untested"},
     "aligner":    {"backend": "qwen3-forcedaligner", "environment": "mlx",
-                   "config": {"scope": "all_segments"},
+                   "config": {"scope": "all_segments",
+                              "language_rule": "Chinese when text matches [一-鿿], otherwise English; the ASR --language hint is never forwarded"},
                    "selected_by": "add_on_required_by:word_timestamps"}
   },
   "execution": {
@@ -259,8 +260,8 @@ audio transcribe plan --input meeting.m4a \
   },
   "capabilities": {
     "diarization":     {"satisfaction": "derived", "backend": "fluidaudio",
-                        "evidence": {"interface": "verified", "quality": "measured"},
-                        "note": "Anonymous labels reconciled sample-exactly onto the ASR text, plus the diarizer's turn intervals. This preset matched 3 of 75 annotated speaker changes on a dense conversation and is not validated for rapid backchannels, interruptions, or dense overlap."
+                        "evidence": {"interface": "verified", "quality": "unmeasured"},
+                        "note": "Anonymous labels are reconciled sample-exactly onto the ASR text, plus the diarizer's turn intervals. The shipped no-prior, overlap-off configuration is unmeasured; the 3-of-75 speaker-change result used a two-speaker prior with overlap detection enabled and does not apply to this request."
                         },
     "word_timestamps": {"satisfaction": "derived", "backend": "qwen3-forcedaligner",
                         "evidence": {"interface": "verified", "quality": "unmeasured"},
@@ -268,7 +269,7 @@ audio transcribe plan --input meeting.m4a \
   },
   "packages": [
     {"package": "qwen3-asr-1.7b-8bit", "environment": "mlx", "kind": "weights",
-     "bytes": 2463307541, "provisioned": false},
+     "bytes": 2467859030, "provisioned": false},
     {"package": "fluidaudio", "environment": "swift", "kind": "toolchain",
      "requires_tool": ["swift"], "bytes": null, "provisioned": false},
     {"package": "speaker-diarization-coreml", "environment": "swift", "kind": "weights",
@@ -276,13 +277,14 @@ audio transcribe plan --input meeting.m4a \
     {"package": "qwen3-forcedaligner", "environment": "mlx", "kind": "weights",
      "bytes": null, "provisioned": false}
   ],
-  "total_known_download_bytes": 2463307541,
+  "total_known_download_bytes": 2467859030,
   "unsized_packages": ["fluidaudio", "speaker-diarization-coreml", "qwen3-forcedaligner"],
   "warnings": [],
   "sample_output": {
     "sample": true,
     "note": "shape only; values are placeholders and cardinality is unknown until run",
     "schema_version": 1,
+    "complete": true,
     "source": {"path": "meeting.m4a", "duration_seconds": 1794.2, "timebase": "seconds"},
     "segments": [
       {"segment_id": "seg_0", "text": null, "speaker": null,
@@ -292,7 +294,7 @@ audio transcribe plan --input meeting.m4a \
       {"turn_id": "turn_0", "speaker": null, "start": null, "end": null}
     ],
     "abstentions": [
-      {"abstention_id": "ab_0", "reason": "overlap", "start": null, "end": null}
+      {"abstention_id": "ab_0", "reason": "raw_fragment", "start": null, "end": null}
     ],
     "provenance": "<stack, outcomes, observed, and the executed plan; elided in print>"
   }
@@ -497,6 +499,7 @@ Exit 0. `meeting.timed.json`:
 ```json
 {
   "schema_version": 1,
+  "complete": true,
   "source": {"path": "meeting.m4a", "duration_seconds": 1794.2, "timebase": "seconds"},
   "segments": [
     {"segment_id": "seg_0", "speaker": "S1",
@@ -526,7 +529,7 @@ Exit 0. `meeting.timed.json`:
     {"turn_id": "turn_1", "speaker": "S2", "start": 5.06, "end": 7.51}
   ],
   "abstentions": [
-    {"abstention_id": "ab_0", "reason": "overlap", "start": 41.86, "end": 42.73},
+    {"abstention_id": "ab_0", "reason": "raw_fragment", "start": 41.86, "end": 42.07},
     {"abstention_id": "ab_1", "reason": "short_turn", "start": 118.44, "end": 118.79}
   ],
   "provenance": {
@@ -631,14 +634,15 @@ audio transcribe plan --input demo.mp4 --stack vibevoice \
                 "determinism_note": "acoustic tokenizer samples a Gaussian latent; fixed seed required",
                 "selected_by": "stack"},
     "aligner": {"backend": "qwen3-forcedaligner", "environment": "mlx",
-                "config": {"scope": "all_segments"},
+                "config": {"scope": "all_segments",
+                           "language_rule": "Chinese when text matches [一-鿿], otherwise English; the ASR --language hint is never forwarded"},
                 "selected_by": "add_on_required_by:word_timestamps"}
   },
   "execution": {
     "stage_order": ["decode", "asr", "aligner"],
     "residency": "one_model_stage_at_a_time",
     "environments_spanned": ["mlx", "torch-vibevoice"],
-    "note": "both model stages share the torch environment and are still not resident together; VibeVoice and the aligner have never been measured co-resident and this plan does not do so"
+    "note": "VibeVoice runs in torch-vibevoice and the aligner runs later in mlx; the two environment processes are not resident together, so stage walls add and peaks do not"
   },
   "capabilities": {
     "verbatim":           {"satisfaction": "native",
@@ -671,6 +675,7 @@ audio transcribe plan --input demo.mp4 --stack vibevoice \
     "sample": true,
     "note": "shape only; values are placeholders and cardinality is unknown until run",
     "schema_version": 1,
+    "complete": true,
     "source": {"path": "demo.mp4", "duration_seconds": 112.4, "timebase": "seconds"},
     "segments": [
       {"segment_id": "seg_0", "text": null, "speaker": null,
@@ -705,6 +710,7 @@ Exit 0. `demo.transcript.json`:
 ```json
 {
   "schema_version": 1,
+  "complete": true,
   "source": {"path": "demo.mp4", "duration_seconds": 112.4, "timebase": "seconds"},
   "segments": [
     {"segment_id": "seg_0", "speaker": "0", "start": 0.0, "end": 4.52,
@@ -836,9 +842,9 @@ audio transcribe plan --input field.wav --stack firered \
   },
   "execution": {
     "stage_order": ["decode", "vad", "lid", "asr", "punctuator"],
-    "residency": "one_model_stage_at_a_time",
+    "residency": "one_environment_process_at_a_time",
     "environments_spanned": ["torch-firered"],
-    "note": "four model stages in one environment, none resident together"
+    "note": "FireRed runs one process that loads VAD, LID, ASR and punctuator together. On the same 139.284-second probe, LID on measured 162.09 s and 13169377280 bytes (12.26 GiB) peak RSS; LID off measured 84.24 s and 9830449152 bytes (9.16 GiB)."
   },
   "capabilities": {
     "verbatim":        {"satisfaction": "native",
@@ -854,7 +860,7 @@ audio transcribe plan --input field.wav --stack firered \
                         "evidence": {"interface": "verified", "quality": "unmeasured"}},
     "lid": {"satisfaction": "native", "stage": "FireRedLID",
                         "evidence": {"interface": "verified", "quality": "unmeasured"},
-                        "note": "one label per VAD region, copied onto every sentence in that region; per-sentence variation would be fabricated"}
+                        "note": "one of the 115 labels after the five special tokens in the pinned FireRedLID dict.txt, emitted once per VAD region and copied onto every sentence in that region; per-sentence variation would be fabricated"}
   },
   "packages": [
     {"package": "firered-asr2s", "environment": "torch-firered", "kind": "weights",
@@ -862,14 +868,12 @@ audio transcribe plan --input field.wav --stack firered \
   ],
   "total_known_download_bytes": 0,
   "unsized_packages": ["firered-asr2s"],
-  "warnings": [
-    {"code": "measured_config_differs_from_plan", "blocking": false,
-     "detail": "the measured block above was recorded with lid off while this plan runs it; expect roughly double the inference time and no measured memory figure for the LID-on path"}
-  ],
+  "warnings": [],
   "sample_output": {
     "sample": true,
     "note": "shape only; values are placeholders and cardinality is unknown until run",
     "schema_version": 1,
+    "complete": true,
     "source": {"path": "field.wav", "duration_seconds": 27.8, "timebase": "seconds"},
     "segments": [
       {"segment_id": "seg_0", "text": null, "start": null, "end": null,
@@ -898,6 +902,7 @@ Exit 0. `field.transcript.json`:
 ```json
 {
   "schema_version": 1,
+  "complete": true,
   "source": {"path": "field.wav", "duration_seconds": 27.8, "timebase": "seconds"},
   "segments": [
     {"segment_id": "seg_0", "start": 0.38, "end": 1.62,
@@ -936,9 +941,8 @@ Exit 0. `field.transcript.json`:
       "stage_wall_seconds": {"decode": 0.09, "vad": 0.61, "lid": 8.83, "asr": 9.14,
                              "punctuator": 1.07},
       "total_wall_seconds": 19.74,
-      "peak_rss_bytes_by_stage": {"vad": 1284407296, "lid": 5871104000,
-                                  "asr": 6903312384, "punctuator": 2415919104},
-      "peak_rss_bytes": 6903312384,
+      "peak_rss_bytes_by_stage": {"firered_process": 13169377280},
+      "peak_rss_bytes": 13169377280,
       "segments": 2,
       "words": 11,
       "vad_regions": 2,
@@ -1006,7 +1010,7 @@ Exit 2:
   "stacks": {
     "qwen-1.7b": "fast transcript, no native timing or speakers; the interview default",
     "qwen-0.6b": "same shape, smaller and faster, measurably worse text",
-    "vibevoice": "native speakers and segment bounds, highest memory, cannot resume a failed run",
+    "vibevoice": "native speakers and segment bounds, highest memory, prefix-only recovery after generation truncation",
     "firered": "native word timing, speech regions and region language; no speakers"
   },
   "fix": "audio transcribe plan --input meeting.m4a --stack qwen-1.7b --want diarization"
@@ -1016,7 +1020,8 @@ Exit 2:
 The `fix` names one stack rather than listing four again, because a fix a caller has to
 choose between is not a fix. `stacks` is there so the choice can be revisited deliberately,
 and the one-liners say what each stack costs as well as what it gives — including that
-`vibevoice` cannot resume, which is the kind of thing nobody discovers until a long run dies.
+`vibevoice` can salvage only a complete decoded prefix after generation truncation, while a
+model-load failure still leaves nothing.
 
 ### 4.2 No input
 
@@ -1140,7 +1145,31 @@ choice and the flag was the accident. `stacks_accepting` is there for the caller
 the opposite. Accepting the flag silently would be the real failure: a caller would believe
 it had constrained a decode it never touched.
 
-### 4.7 A pin the plan has no role for
+### 4.7 An unsupported option value
+
+```bash
+audio transcribe plan --input meeting.m4a --stack qwen-1.7b --language EN
+```
+
+Exit 2:
+
+```json
+{
+  "code": "option_value_unsupported",
+  "field": "--language",
+  "provided": "EN",
+  "allowed": ["Chinese", "English", "Cantonese", "Arabic", "German", "French", "Spanish", "Portuguese", "Indonesian", "Italian", "Korean", "Russian", "Thai", "Vietnamese", "Japanese", "Turkish", "Hindi", "Malay", "Dutch", "Swedish", "Danish", "Finnish", "Polish", "Czech", "Filipino", "Persian", "Greek", "Romanian", "Hungarian", "Macedonian"],
+  "did_you_mean": "English",
+  "fix": "audio transcribe plan --input meeting.m4a --stack qwen-1.7b --language English"
+}
+```
+
+The value is matched case-insensitively but not by abbreviation: `english` resolves to the
+canonical `English`, while `EN` is not one of the checkpoint's declared names. `allowed` is the
+exact `support_languages` list published by both pinned Qwen configs; `did_you_mean` is optional
+and appears only for a near value.
+
+### 4.8 A pin the plan has no role for
 
 ```bash
 audio transcribe plan --input demo.mp4 --stack vibevoice --want diarization --diarizer fluidaudio
@@ -1162,7 +1191,7 @@ Exit 2:
 `vibevoice` satisfies `diarization` natively, so this plan contains no diarizer role for a
 pin to select among. Pins choose between implementations of a role that exists.
 
-### 4.8 The rest
+### 4.9 The rest
 
 | Code | Exit | Trigger | What `fix` says |
 | --- | --- | --- | --- |

--- a/TRANSCRIBE_IMPLEMENTATION_PLAN.md
+++ b/TRANSCRIBE_IMPLEMENTATION_PLAN.md
@@ -43,16 +43,15 @@ unconditional and its test must run the **no-hint** configuration, or it passes 
 configuration that never leaks. `mlx-audio` exposes `extract_language`
 (`qwen3_asr.py:899`) — the adapter calls it rather than matching a prefix by hand.
 
-**3. The aligner's `language` is a tokenizer selector with a Cantonese trap.**
-`qwen3_forced_aligner.py:256-266` lowercases the argument and branches four ways —
-`japanese`, `korean`, `chinese`, and everything else to `tokenize_space_lang`. Its checkpoint
-declares **eleven** supported languages including `Cantonese`, and there is no Cantonese
-branch, so `--language Cantonese` plumbed through would space-split CJK text into one "word"
-per segment and silently degenerate `word_timestamps` — on the exact configuration every
-recorded Cantonese figure used. This is why the recorded pipeline derives the aligner's
-language from a CJK regex (`run_mlx_forced_aligner_probe.py:55,94`) instead of passing the
-ASR's through, and why that rule is declared configuration here rather than an invisible
-heuristic.
+**3. The aligner's recorded `language` rule is not the ASR hint, and the pinned source does not
+support the previously claimed Cantonese trap.** The recorded pipeline derives `Chinese` or
+`English` from a CJK regex (`run_mlx_forced_aligner_probe.py:55,94`) instead of passing the ASR
+hint through. The pinned implementation branches only for `japanese` and `korean`; every other
+value, including `chinese`, `cantonese`, and `english`, uses `tokenize_space_lang`, whose own
+CJK splitter emits ideographs individually (`qwen3_forced_aligner.py:129-145,236-247`). The
+earlier claim that Chinese had a dedicated branch while Cantonese would collapse a segment to
+one word was false. The CJK rule remains declared configuration because it is what produced the
+recorded equivalence result, not because source proves it superior to the unmeasured alternative.
 
 **4. A truncated VibeVoice decode loses the whole transcript upstream, not just its tail.**
 `post_process_transcription` finds the closing bracket by counting (`:514-524`, commit
@@ -116,7 +115,7 @@ left open or corrects something the evidence pass found.
 | **FireRed runs as one subprocess**, four Hub repositories in one package, three or four models loaded by request. | Provisioning and residency are different questions and only the second was wrong. One package, one download, one process is the measured configuration; splitting into four subprocesses would reimplement `FireRedAsr2System.process`'s glue, pay four model loads, and invalidate every recorded FireRed figure. `execution.residency` is corrected to the granularity that holds instead. |
 | **No `--speakers` flag.** The diarizer estimates its own speaker count. | Simpler surface, and mechanically safe: `fluidaudiocli`'s offline options are "all optional" and `--num-speakers` merely overrides min/max. Cost, recorded rather than hidden: every cited diarization figure passed `--num-speakers 2`, so the shipped configuration is not the measured one. |
 | **`--language` stays, as a closed enum on the Qwen stacks only.** 30 declared names, matched case-insensitively, passed through verbatim, refused otherwise. | `_build_prompt` (`qwen3_asr.py:926-929`) falls back to the raw string when a name misses, so `--language EN` would interpolate `language EN<asr_text>` into the prompt with no error — a flag that parses and silently changes the decode. The accepted set is closed and readable, so refusing is possible without any translation table. Dropping the flag instead would return every recorded Qwen figure to a configuration no caller can request. |
-| **The language hint never reaches the aligner.** `roles.aligner.config.language_rule` declares the recorded CJK rule verbatim. | Finding 3. Two parameters answering one question can only disagree, and here one of the answers breaks CJK alignment. |
+| **The language hint never reaches the aligner.** `roles.aligner.config.language_rule` declares the recorded CJK rule verbatim. | Finding 3, corrected against the pinned source: the rule is measured provenance. Chinese and Cantonese share the same fallback tokenizer, so no relative quality claim is made without a comparison run. |
 | **A truncated VibeVoice run exits 4 with the prefix it decoded.** `failure_recovery.partial_results` gains `prefix_only`; `none` is retired. | Finding 4: at 6.30 tok/s the cap lands inside the target use case, and losing a forty-minute transcript to an unterminated bracket is the worst available outcome. The cost is that the adapter owns a salvage parse rather than reading a field. `none` is retired because `vibevoice` was its only holder, and an enum member nothing reaches is the `satisfaction: unavailable` mistake. |
 | **`--overlapping-segments` is passed only when `overlapped_speech` is requested.** | Owner's decision. It obliges an attribution fix rather than a note tweak: the 95.42 % participant-interval F1 *and* the 33.56 % MER both trace to a diarization run with the flag on, and that run shaped the turn set the MER was scored against — 589 raw segments to 195 accepted turns, 9 overlap abstentions, 33 short turns, 54 raw-fragment-only spans. The overlap-off configuration is unmeasured and the catalog says so. |
 | **`complete` is always present in a result.** `coverage` appears only when it is `false`. | The one place where absence would be dangerous rather than meaningful: a saved document outlives its exit code, and `export` has to branch on it when merging. Every other absence rule is unchanged. |
@@ -303,7 +302,7 @@ convention.
 
 *Acceptance.* `capabilities` and `plan` output diffed key-for-key against HAPPY_PATH §1.1,
 §1.2, §2.1, §3.1 by the `shape()` comparison `test_shipped_commands_match_the_document.py`
-already defines, extended to the new commands. Every refusal in §4.1–4.7 and CONTRACT §5
+already defines, extended to the new commands. Every refusal in §4.1–4.8 and CONTRACT §5
 reproduced field-for-field against the per-code table, with `capability_unknown`,
 `capability_unsatisfiable_on_stack`, and `capability_unsupported` distinct. `--language EN`
 returns `option_value_unsupported` with `did_you_mean: "English"`; `--language english`
@@ -374,7 +373,7 @@ target:
 
 | Where | Change |
 | --- | --- |
-| CONTRACT §1.1, §1.2 and HAPPY_PATH §1.2 (5 occurrences) | `bytes: 2463307541` → `2467859030`. The manifest carries the measured figure and `tests/test_environments.py:205` retires this exact number as illustrative. |
+| CONTRACT §1.1, §1.2 and HAPPY_PATH §1.2 (all occurrences) | `bytes: 2463307541` → `2467859030`. The manifest carries the measured figure and `tests/test_environments.py` retires this exact number as illustrative. |
 | HAPPY_PATH §1.1 `word_timestamps` note | "Adds Qwen3-ForcedAligner in the torch environment, so this request spans three" → the aligner runs in `mlx` beside the ASR and adds no runtime. |
 | HAPPY_PATH §2.1 `execution.note` | "both model stages share the torch environment" contradicts `environments_spanned: ["mlx", "torch-vibevoice"]` one line above. |
 | HAPPY_PATH §3.1 `execution` and `observed` | Residency corrected to environment granularity; illustrative peaks replaced by the measured 9.12 GiB (LID off) / 12.26 GiB (LID on) pair. |
@@ -396,7 +395,8 @@ Additions — names and rows this plan needs that no document yet carries:
   three-way capability split exists precisely so two different failures are not rendered alike.
 - The 30 accepted `--language` names, cited to `config.json:support_languages` at both pinned
   Qwen revisions, and FireRedLID's label vocabulary cited to `dict.txt`.
-- `roles.aligner.config.language_rule`, and the Cantonese trap as its reason.
+- `roles.aligner.config.language_rule`, with the recorded CJK selection rule and the explicit
+  source finding that Chinese and Cantonese share the same fallback tokenizer.
 
 ## Test strategy
 
@@ -435,8 +435,9 @@ New, from this pass:
 - **VibeVoice's 43-minute cap is a rate extrapolation**, not an observed truncation. No recorded
   run hit `hit_max_new_tokens`.
 - **The aligner's language rule is unmeasured against alternatives.** The CJK rule is the one the
-  equivalence probe used; whether a different rule would align better is untested, and the
-  Cantonese branch's absence is read from source rather than from a failed run.
+  equivalence probe used; whether a different rule would align better is untested. The pinned
+  source branches only for Japanese and Korean and sends both Chinese and Cantonese through the
+  same fallback, so it supplies no basis for preferring one of those names.
 
 Carried from [HANDOFF.md](HANDOFF.md), unchanged: boundary MAE/P95 for FireRed's native word
 times and for the aligner; filler recall on any stack; cross-process determinism for the Qwen

--- a/VOCABULARY.md
+++ b/VOCABULARY.md
@@ -171,6 +171,13 @@ printed**, on the same reasoning as the floors: a caller cannot select any of it
 in every plan invited a reader to mistake it for a set of settings, and the thresholds are
 fixed by the tool version rather than by the request.
 
+The three thresholds are `raw_fragment_min_ms: 250`, `accepted_turn_min_ms: 500`, and
+`same_label_merge_max_ms: 300`, exactly as declared by
+`model_tests/benchmark/run_turn_attributed_mlx_asr.py:78-84`. A raw diarizer fragment below
+250 ms is not transcribed; same-label fragments separated by at most 300 ms are merged; a
+resulting turn below 500 ms is not transcribed. The two declined cases become `raw_fragment`
+and `short_turn` abstentions respectively. Ambiguous multi-speaker activity becomes `overlap`.
+
 The one part a caller must not miss is a trap, so it is surfaced where it is actionable rather
 than buried in a block: when nothing in a plan detects overlap, an empty abstention ledger
 means *undetected*, not *absent*. That is a plan warning and a line in the
@@ -213,16 +220,37 @@ are outputs that report one. A stack declares whether it accepts an input in its
 rather than a silently ignored argument. This is the only caller-settable model input
 in v1.
 
+Qwen accepts exactly these 30 names, case-insensitively and normalized to the spelling shown:
+`Chinese`, `English`, `Cantonese`, `Arabic`, `German`, `French`, `Spanish`, `Portuguese`,
+`Indonesian`, `Italian`, `Korean`, `Russian`, `Thai`, `Vietnamese`, `Japanese`, `Turkish`,
+`Hindi`, `Malay`, `Dutch`, `Swedish`, `Danish`, `Finnish`, `Polish`, `Czech`, `Filipino`,
+`Persian`, `Greek`, `Romanian`, `Hungarian`, `Macedonian`. The source is `support_languages`
+in both pinned checkpoint configs:
+[`Qwen3-ASR-1.7B-8bit`](https://huggingface.co/mlx-community/Qwen3-ASR-1.7B-8bit/blob/a8379a2e2f9e313c9292cdf1af4055ab56d50d55/config.json)
+and [`Qwen3-ASR-0.6B-8bit`](https://huggingface.co/mlx-community/Qwen3-ASR-0.6B-8bit/blob/89e96d92ba34aca20b3e29fb10cc284097d1219f/config.json).
+
+FireRed accepts no language input. Its `lid` output uses the 115 labels after the five special
+tokens in the pinned
+[`FireRedLID` dictionary](https://huggingface.co/FireRedTeam/FireRedLID/blob/1bb4d285c8456429385d9c0810300df4297bc11b/dict.txt):
+
+```text
+en es fr zh other xinan ja ko ru mandarin min wu xiang yue north de pt ab af am ar as az ba be bg bn br ca cs cy da el eo et eu fa gl gn ha iw hi ht hu hy ia id is it ka kk lo lt lv mk ml mn mr mt no ne nl nn oc pa pl ps ro sd sk sl sq sr sv sw ta te tg th tk tr tt uk ur uz vi yi yo kn so ceb jw mi hr bs tl ln my fi sn lb gu ms km bo fo gv haw la mg sa sco si su war
+```
+
+These vocabularies are not reconciled: Qwen calls its input `Cantonese`, while FireRed emits
+`yue`. Translating between them would be a separate declared policy, not spelling cleanup.
+
 **unit** — the piece of audio a stack actually works on, and the granularity at which a
 run can be partial. Qwen works in diarized turns when speaker structure is requested and
 in fixed chunks otherwise; FireRed works in VAD regions; VibeVoice is handed whole media
 in a single call and therefore has exactly one unit. The unit is a stack property, but
 *how many* units a given file yields is a property of the pair, which is why an input is
 required to plan. Where the count depends on content the plan has not decoded, it is
-reported absent rather than guessed.
+reported as the fixed structural field `unit_count: null` rather than guessed.
 
-**coverage** — which parts of the source a result actually covers, carried by any run that
-did not finish. It holds a `covered_through_seconds` watermark — the end of the longest
+**coverage** — which parts of the source a result actually covers. Every result carries the
+boolean `complete`; `coverage` is present if and only if `complete` is `false`. It holds a
+`covered_through_seconds` watermark — the end of the longest
 contiguous transcribed prefix, the one number a caller can act on without reasoning about
 gaps — plus explicit `covered_intervals` and `missing_intervals`, because completion is not
 necessarily contiguous in time: the recorded Qwen runner processes turns in
@@ -235,22 +263,26 @@ is arithmetic on timestamps performed outside the tool and precisely what the
 canonical-timeline floor exists to prevent.
 
 **failure_recovery** — a stack's declared answer to what a failure leaves behind:
-`partial_results` of `per_unit` or `none`, and whether it is `resumable`. It belongs in
-the `capabilities` report because it is a stack-choice input, not a run-time discovery. It is `none` on
-`vibevoice`, so on a long file the most likely failure lands on the one stack that cannot
-resume.
+`partial_results` of `per_unit` or `prefix_only`, and whether it is `resumable`. It belongs in
+the `capabilities` report because it is a stack-choice input, not a run-time discovery. Qwen
+and FireRed preserve completed independent units. VibeVoice is `prefix_only`: a generation-cap
+truncation can salvage complete parsed segments before the cut and resume the remainder, while
+a failure before any complete segment — including OOM at model load — leaves no result.
 
-**execution** — the plan's statement of stage order and model residency. Stages run
-strictly sequentially and no two model stages are resident at once, so a request costs
-the sum of the stage walls and the maximum of the stage peaks. This is declared rather
-than left implicit because every recorded figure was produced by strictly sequential
-fresh subprocesses whose record states that the stages did not overlap; per-stage memory
-peaks published without it invite summing. It is also what keeps the largest stack's
-memory claim honest, since VibeVoice and the aligner have never been measured resident
-together.
+**execution** — the plan's statement of stage order and residency at environment-process
+granularity. Environment processes run strictly sequentially, so a request costs the sum of
+their walls and the maximum of their peaks. Qwen and VibeVoice use one fresh process per model
+stage. FireRed is the deliberate exception: one `torch-firered` process loads its VAD, LID,
+ASR, and punctuator models co-resident, and only that process-level peak is meaningful. The
+plan must never turn one package or one environment into a claim that those models were loaded
+one at a time. VibeVoice and the later MLX aligner remain separate environment processes and
+have never been measured co-resident.
 
-**abstention** — a recorded refusal to assert, carrying an interval and a
-reason. Abstentions must survive to the output.
+**abstention** — a recorded refusal to assert, carrying an interval and a `reason` from exactly
+three allowed values: `overlap` for ambiguous multi-speaker activity, `short_turn` for an
+accepted turn below 500 ms, and `raw_fragment` for a span whose only activity was a sub-250 ms
+diarizer fragment. Abstentions must survive to the output. Budget-unprocessed intervals are
+coverage, not abstentions, because the tool did not reach them rather than declining to assert.
 
 ## Floors
 
@@ -583,6 +615,11 @@ keeps a flat enum a caller can switch on rather than an object restating it.
   (`fireredasr2system.py:181-184`). What it does emit is `asr_confidence` per
   *sentence*, which is a different granularity and is not requestable in v1. Do
   not reintroduce the name for the sentence value.
+- **unit_count_known_at_plan_time** — retired because `processing` already has the fixed
+  `unit_count` field. Its unknown value is `null`; a second boolean can only disagree with it.
+- **none** under `failure_recovery.partial_results` — retired when VibeVoice gained
+  `prefix_only` salvage. Failures that produce no complete prefix still write no result; they
+  do not need an enum member in a catalog of what partial results can contain.
 
 ## Versioning
 

--- a/src/audio_cli/environments/__init__.py
+++ b/src/audio_cli/environments/__init__.py
@@ -76,6 +76,13 @@ class Package:
         return self.bytes is not None
 
 
+@dataclass(frozen=True)
+class Backend:
+    id: str
+    package: str
+    role: str
+
+
 @cache
 def _raw() -> dict:
     document = json.loads(MANIFEST.read_text())
@@ -127,6 +134,19 @@ def packages() -> dict[str, Package]:
     return out
 
 
+@cache
+def backends() -> dict[str, Backend]:
+    """Backend ids resolved by a plan, and the package and role each one supplies."""
+    return {
+        identifier: Backend(
+            id=identifier,
+            package=body["package"],
+            role=body["role"],
+        )
+        for identifier, body in _raw()["backends"].items()
+    }
+
+
 def packages_for(stack: str, roles: dict[str, str]) -> list[Package]:
     """Packages a resolved plan needs.
 
@@ -138,7 +158,8 @@ def packages_for(stack: str, roles: dict[str, str]) -> list[Package]:
     `audio doctor` rather than provisioned.
     """
     catalog = packages()
-    unknown = sorted(set(roles.values()) - set(catalog) - {"ffmpeg"})
+    backend_catalog = backends()
+    unknown = sorted(set(roles.values()) - set(backend_catalog) - {"ffmpeg"})
     if unknown:
         raise ManifestError(f"no package supplies backend(s) {unknown} for stack {stack!r}")
 
@@ -146,10 +167,17 @@ def packages_for(stack: str, roles: dict[str, str]) -> list[Package]:
     for role, backend in roles.items():
         if backend == "ffmpeg":
             continue
-        package = catalog[backend]
-        if role not in package.roles:
+        binding = backend_catalog[backend]
+        if role != binding.role:
             raise ManifestError(
-                f"{backend!r} does not fill the {role!r} role; manifest lists {package.roles}"
+                f"{backend!r} does not fill the {role!r} role; manifest maps it to "
+                f"{binding.role!r}"
+            )
+        package = catalog[binding.package]
+        if stack not in package.stacks:
+            raise ManifestError(
+                f"{backend!r} does not support stack {stack!r}; package {package.id!r} "
+                f"lists {package.stacks}"
             )
         wanted[package.id] = package
         # A Core ML model package rides along with the toolchain that loads it.
@@ -196,7 +224,8 @@ def validate() -> list[str]:
     """
     problems: list[str] = []
     known_environments = environments()
-    for package in packages().values():
+    known_packages = packages()
+    for package in known_packages.values():
         if package.environment not in known_environments:
             problems.append(f"{package.id}: unknown environment {package.environment!r}")
         for role in package.roles:
@@ -217,6 +246,19 @@ def validate() -> list[str]:
                     f"repos' bytes {declared}"
                 )
 
+    for backend in backends().values():
+        package = known_packages.get(backend.package)
+        if package is None:
+            problems.append(f"{backend.id}: unknown package {backend.package!r}")
+            continue
+        if backend.role not in ROLES:
+            problems.append(f"{backend.id}: {backend.role!r} is not a role")
+        elif backend.role not in package.roles:
+            problems.append(
+                f"{backend.id}: maps to role {backend.role!r}, but package {package.id!r} "
+                f"lists {package.roles}"
+            )
+
     for environment in known_environments.values():
         if environment.provisioned and environment.has_interpreter:
             if environment.lock is None:
@@ -225,7 +267,7 @@ def validate() -> list[str]:
                 problems.append(f"{environment.name}: lock {environment.lock.name} is missing")
         if not environment.provisioned and environment.lock is not None:
             problems.append(f"{environment.name}: not provisioned but names a lock")
-        members = [p for p in packages().values() if p.environment == environment.name]
+        members = [p for p in known_packages.values() if p.environment == environment.name]
         if environment.provisioned and not members:
             problems.append(f"{environment.name}: provisioned but no package targets it")
     return problems

--- a/src/audio_cli/environments/manifest.json
+++ b/src/audio_cli/environments/manifest.json
@@ -71,6 +71,18 @@
       "reason": "A Swift build product plus one Core ML model package. No interpreter, so no lock; absent `swift` blocks only these packages and is reported by `audio doctor` rather than being fatal."
     }
   },
+  "backends": {
+    "silero-vad": {"package": "silero-vad", "role": "vad"},
+    "qwen3-asr-1.7b-8bit": {"package": "qwen3-asr-1.7b-8bit", "role": "asr"},
+    "qwen3-asr-0.6b-8bit": {"package": "qwen3-asr-0.6b-8bit", "role": "asr"},
+    "qwen3-forcedaligner": {"package": "qwen3-forcedaligner", "role": "aligner"},
+    "vibevoice-asr-7b": {"package": "vibevoice-asr-7b", "role": "asr"},
+    "firered-vad": {"package": "firered-asr2s", "role": "vad"},
+    "firered-lid": {"package": "firered-asr2s", "role": "lid"},
+    "firered-asr2-aed": {"package": "firered-asr2s", "role": "asr"},
+    "firered-punc": {"package": "firered-asr2s", "role": "punctuator"},
+    "fluidaudio": {"package": "fluidaudio", "role": "diarizer"}
+  },
   "packages": {
     "silero-vad": {
       "environment": "core",

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -196,8 +196,26 @@ def test_packages_for_rejects_a_backend_that_does_not_fill_the_role() -> None:
     """The mapping is only useful if a wrong pairing fails loudly rather than silently."""
     with pytest.raises(env.ManifestError, match="does not fill"):
         env.packages_for("qwen-1.7b", {"asr": "qwen3-forcedaligner"})
+    with pytest.raises(env.ManifestError, match="does not fill"):
+        env.packages_for("firered", {"asr": "firered-lid"})
     with pytest.raises(env.ManifestError, match="no package supplies"):
         env.packages_for("qwen-1.7b", {"asr": "whisper-large"})
+
+
+def test_packages_for_resolves_all_firered_backends_to_one_package() -> None:
+    selection = env.packages_for("firered", {
+        "decode": "ffmpeg",
+        "vad": "firered-vad",
+        "lid": "firered-lid",
+        "asr": "firered-asr2-aed",
+        "punctuator": "firered-punc",
+    })
+    assert [package.id for package in selection] == ["firered-asr2s"]
+
+
+def test_packages_for_rejects_a_backend_from_another_stack() -> None:
+    with pytest.raises(env.ManifestError, match="does not support stack"):
+        env.packages_for("qwen-1.7b", {"asr": "qwen3-asr-0.6b-8bit"})
 
 
 def test_manifest_byte_counts_are_not_the_illustrative_ones_the_specs_used() -> None:
@@ -208,6 +226,16 @@ def test_manifest_byte_counts_are_not_the_illustrative_ones_the_specs_used() -> 
             f"{package.id} carries {package.bytes}, one of the illustrative figures the spec "
             "documents used before real sizes were read from the Hub"
         )
+
+
+def test_spec_documents_do_not_quote_retired_package_byte_counts() -> None:
+    retired = {2463307541, 18253611008, 9878424576, 1932735283, 84279296}
+    for path in SPEC_DOCS:
+        body = path.read_text()
+        for byte_count in retired:
+            assert str(byte_count) not in body, (
+                f"{path.name} still quotes retired illustrative byte count {byte_count}"
+            )
 
 
 def test_silero_digest_matches_the_shipped_backend() -> None:

--- a/tests/test_spec_docs.py
+++ b/tests/test_spec_docs.py
@@ -72,10 +72,20 @@ RETIRED_KEYS = frozenset({
     "measured",
     # deterministic glue is not a role
     "reconciler",
+    # contradicted the fixed processing.unit_count field
+    "unit_count_known_at_plan_time",
 })
 
-SAMPLE_META = frozenset({"sample", "note", "schema_version", "source", "segments",
+SAMPLE_META = frozenset({"sample", "note", "schema_version", "complete", "source", "segments",
                          "abstentions", "provenance"})
+
+QWEN_LANGUAGES = (
+    "Chinese", "English", "Cantonese", "Arabic", "German", "French", "Spanish",
+    "Portuguese", "Indonesian", "Italian", "Korean", "Russian", "Thai", "Vietnamese",
+    "Japanese", "Turkish", "Hindi", "Malay", "Dutch", "Swedish", "Danish", "Finnish",
+    "Polish", "Czech", "Filipino", "Persian", "Greek", "Romanian", "Hungarian",
+    "Macedonian",
+)
 
 
 def json_blocks(path: Path) -> list[tuple[int, object]]:
@@ -112,6 +122,14 @@ def is_result(doc) -> bool:
 
 def is_plan(doc) -> bool:
     return isinstance(doc, dict) and "sample_output" in doc
+
+
+def valid_completion_shape(doc: dict) -> bool:
+    """A result says whether it finished, and explains its gaps only when it did not."""
+    return (
+        isinstance(doc.get("complete"), bool)
+        and ("coverage" in doc) is (not doc["complete"])
+    )
 
 
 @pytest.mark.parametrize("path", SPEC_DOCS, ids=lambda p: p.name)
@@ -188,6 +206,61 @@ def test_most_fixes_are_runnable_commands() -> None:
     )
 
 
+def test_language_option_errors_keep_distinct_exact_shapes() -> None:
+    """A bad value and an unsupported option are different corrections."""
+    errors = {
+        doc["code"]: doc
+        for _, doc in json_blocks(HAPPY_PATH)
+        if isinstance(doc, dict) and "code" in doc
+    }
+    unsupported = errors["option_unsupported_on_stack"]
+    assert set(unsupported) == {
+        "code", "field", "provided", "allowed", "stacks_accepting", "fix",
+    }
+    assert unsupported["allowed"] == []
+
+    bad_value = errors["option_value_unsupported"]
+    assert set(bad_value) == {
+        "code", "field", "provided", "allowed", "did_you_mean", "fix",
+    }
+    assert tuple(bad_value["allowed"]) == QWEN_LANGUAGES
+    assert bad_value["did_you_mean"] == "English"
+
+
+@pytest.mark.parametrize("path", SPEC_DOCS, ids=lambda p: p.name)
+def test_results_and_samples_declare_completeness(path: Path) -> None:
+    """Saved output must carry its completion state after the exit code is gone."""
+    for index, doc in json_blocks(path):
+        candidates = []
+        if is_result(doc):
+            candidates.append(("result", doc))
+        if is_plan(doc):
+            candidates.append(("sample_output", doc["sample_output"]))
+        for kind, candidate in candidates:
+            assert valid_completion_shape(candidate), (
+                f"{path.name} block {index}: {kind} must carry coverage iff complete is false"
+            )
+
+
+@pytest.mark.parametrize("candidate", [
+    {"complete": True, "coverage": {}},
+    {"complete": False},
+    {"coverage": {}},
+])
+def test_completion_shape_rejects_each_invalid_state(candidate: dict) -> None:
+    """Both directions of the iff must be reachable even before an incomplete sample ships."""
+    assert not valid_completion_shape(candidate)
+
+
+@pytest.mark.parametrize("candidate", [
+    {"complete": True},
+    {"complete": False, "coverage": {}},
+])
+def test_completion_shape_accepts_each_valid_state(candidate: dict) -> None:
+    """The complete and incomplete forms are both legal, not just rejectable mutations."""
+    assert valid_completion_shape(candidate)
+
+
 @pytest.mark.parametrize("path", SPEC_DOCS, ids=lambda p: p.name)
 def test_results_carry_no_key_for_an_unrequested_capability(path: Path) -> None:
     """The anti-fabrication guarantee: absence is meaningful, so it must be exact."""
@@ -195,7 +268,10 @@ def test_results_carry_no_key_for_an_unrequested_capability(path: Path) -> None:
         if not is_result(doc):
             continue
         requested = set(doc["provenance"]["outcomes"])
-        body = set(doc) - {"schema_version", "source", "segments", "abstentions", "provenance"}
+        body = set(doc) - {
+            "schema_version", "complete", "coverage", "source", "segments", "abstentions",
+            "provenance",
+        }
         for capability, array in CAPABILITY_ARRAYS.items():
             if array in body:
                 assert capability in requested, (


### PR DESCRIPTION
## Summary

- correct the phase-zero transcription specs against pinned runner sources and recorded artifacts
- define result completion, failure recovery, abstention, language, refusal, and process-residency contracts
- add a backend-to-package-role manifest map so all FireRed backends resolve to the single firered-asr2s package
- add regression tests for retired figures, exact error shapes, manifest routing, and both directions of the complete/coverage invariant

## Evidence correction

The issue described a Cantonese-specific forced-aligner tokenizer trap. Adversarial review against the pinned source found that premise was wrong: the implementation branches only for Japanese and Korean, while Chinese and Cantonese share the same fallback tokenizer. This PR corrects the implementation plan and contract to preserve the recorded CJK language rule as provenance without claiming an unsupported Chinese-vs-Cantonese quality difference.

## Verification

- uv run --extra dev pytest — 192 passed
- git diff --check
- Claude adversarial review iterated over code/tests and documentation/evidence until both returned NO ACTIONABLE FINDINGS

Closes #18