### PR TITLE
Transcribe phase A: normalize results and samples

### DIFF
--- a/src/audio_cli/transcribe/__init__.py
+++ b/src/audio_cli/transcribe/__init__.py
@@ -1,0 +1,25 @@
+"""Pure transcription planning and result primitives.
+
+Backends and command wiring land in later phases.  This package starts with the durable result
+shape so every later adapter has one normalization boundary to target.
+"""
+
+from .result import (
+    ABSENT,
+    ABSTENTION_REASONS,
+    CAPABILITY_NAMES,
+    NormalizedResult,
+    ResultError,
+    serialize_result,
+)
+from .sample import build_sample_output
+
+__all__ = [
+    "ABSENT",
+    "ABSTENTION_REASONS",
+    "CAPABILITY_NAMES",
+    "NormalizedResult",
+    "ResultError",
+    "build_sample_output",
+    "serialize_result",
+]

--- a/src/audio_cli/transcribe/result.py
+++ b/src/audio_cli/transcribe/result.py
@@ -1,0 +1,527 @@
+"""The normalized transcription result and its only serializer.
+
+The serializer owns capability-gated absence.  Adapters provide normalized JSON-safe mappings;
+they do not decide which optional keys are legal, and samples use this same function rather than
+maintaining a second rendering path.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+CAPABILITY_NAMES = frozenset({
+    "languages",
+    "verbatim",
+    "diarization",
+    "overlapped_speech",
+    "vad",
+    "word_timestamps",
+    "segment_timestamps",
+    "lid",
+    "token_lid",
+})
+
+ABSTENTION_REASONS = frozenset({"overlap", "short_turn", "raw_fragment"})
+
+_ARRAY_CAPABILITIES = {
+    "diarization": "turns",
+    "vad": "vad_regions",
+    "lid": "lid_regions",
+    "overlapped_speech": "overlapped_speech",
+}
+
+_SEGMENT_CAPABILITIES = {
+    "speaker": "diarization",
+    "words": "word_timestamps",
+    "start": "segment_timestamps",
+    "end": "segment_timestamps",
+}
+
+
+class ResultError(ValueError):
+    """A normalized result violates the schema or its resolved capability set."""
+
+
+class _Absent:
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "ABSENT"
+
+
+ABSENT = _Absent()
+
+JsonMapping = Mapping[str, Any]
+OptionalArray = Sequence[JsonMapping] | _Absent
+OptionalMapping = JsonMapping | _Absent
+
+
+@dataclass(frozen=True)
+class NormalizedResult:
+    """Normalized values plus the resolved capabilities that license their optional keys."""
+
+    source: JsonMapping
+    segments: Sequence[JsonMapping]
+    abstentions: Sequence[JsonMapping]
+    provenance: JsonMapping
+    requested_capabilities: frozenset[str]
+    complete: bool = True
+    coverage: OptionalMapping = ABSENT
+    turns: OptionalArray = ABSENT
+    vad_regions: OptionalArray = ABSENT
+    lid_regions: OptionalArray = ABSENT
+    overlapped_speech: OptionalArray = ABSENT
+    sample: bool = False
+    note: str | None = None
+
+
+def _capabilities(values: Iterable[str]) -> frozenset[str]:
+    found = frozenset(values)
+    unknown = sorted(found - CAPABILITY_NAMES)
+    if unknown:
+        raise ResultError(f"unknown requested capabilities: {unknown}")
+    if "token_lid" in found:
+        raise ResultError("token_lid is unsupported by every stack and cannot appear in a result")
+    return found
+
+
+def _number(value: object, field: str, *, nullable: bool = False) -> float | None:
+    if nullable and value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ResultError(f"{field} must be a finite number")
+    found = float(value)
+    if not math.isfinite(found):
+        raise ResultError(f"{field} must be a finite number")
+    return found
+
+
+def _exact_keys(item: JsonMapping, expected: set[str], field: str) -> None:
+    actual = set(item)
+    if actual != expected:
+        raise ResultError(
+            f"{field} has keys {sorted(actual)}, expected {sorted(expected)}"
+        )
+
+
+def _validate_source(source: JsonMapping) -> float:
+    _exact_keys(source, {"path", "duration_seconds", "timebase"}, "source")
+    if not isinstance(source["path"], str) or not source["path"]:
+        raise ResultError("source.path must be a non-empty string")
+    duration = _number(source["duration_seconds"], "source.duration_seconds")
+    assert duration is not None
+    if duration < 0:
+        raise ResultError("source.duration_seconds must not be negative")
+    if source["timebase"] != "seconds":
+        raise ResultError("source.timebase must be 'seconds'")
+    return duration
+
+
+def _validate_bounds(item: JsonMapping, field: str, *, sample: bool) -> None:
+    has_start = "start" in item
+    has_end = "end" in item
+    if has_start != has_end:
+        raise ResultError(f"{field} must carry start and end together")
+    if not has_start:
+        return
+    start = _number(item["start"], f"{field}.start", nullable=sample)
+    end = _number(item["end"], f"{field}.end", nullable=sample)
+    if sample:
+        if start is not None or end is not None:
+            raise ResultError(f"{field} placeholder bounds must be null")
+        return
+    assert start is not None and end is not None
+    if start < 0 or end < start:
+        raise ResultError(f"{field} bounds must satisfy 0 <= start <= end")
+
+
+def _validate_words(words: object, field: str, *, sample: bool) -> None:
+    if not isinstance(words, (list, tuple)):
+        raise ResultError(f"{field} must be an array")
+    for index, word in enumerate(words):
+        if not isinstance(word, Mapping):
+            raise ResultError(f"{field}[{index}] must be an object")
+        name = f"{field}[{index}]"
+        _exact_keys(word, {"word_id", "text", "start", "end"}, name)
+        if not isinstance(word["word_id"], str) or not word["word_id"]:
+            raise ResultError(f"{name}.word_id must be a non-empty string")
+        if sample:
+            if word["text"] is not None:
+                raise ResultError(f"{name}.text placeholder must be null")
+        elif not isinstance(word["text"], str):
+            raise ResultError(f"{name}.text must be a string")
+        _validate_bounds(word, name, sample=sample)
+
+
+def _validate_segments(
+    segments: Sequence[JsonMapping],
+    requested: frozenset[str],
+    *,
+    sample: bool,
+) -> None:
+    for index, segment in enumerate(segments):
+        if not isinstance(segment, Mapping):
+            raise ResultError(f"segments[{index}] must be an object")
+        field = f"segments[{index}]"
+        allowed = {"segment_id", "text"} | set(_SEGMENT_CAPABILITIES)
+        extra = set(segment) - allowed
+        if extra:
+            raise ResultError(f"{field} carries unknown keys {sorted(extra)}")
+        if not {"segment_id", "text"} <= set(segment):
+            raise ResultError(f"{field} must carry segment_id and text")
+        if not isinstance(segment["segment_id"], str) or not segment["segment_id"]:
+            raise ResultError(f"{field}.segment_id must be a non-empty string")
+        if sample:
+            if segment["text"] is not None:
+                raise ResultError(f"{field}.text placeholder must be null")
+        elif not isinstance(segment["text"], str):
+            raise ResultError(f"{field}.text must be a string")
+        for key, capability in _SEGMENT_CAPABILITIES.items():
+            if key in segment and capability not in requested:
+                raise ResultError(
+                    f"{field}.{key} requires requested capability {capability!r}"
+                )
+        if "speaker" in segment:
+            if sample and segment["speaker"] is not None:
+                raise ResultError(f"{field}.speaker placeholder must be null")
+            if not sample and not isinstance(segment["speaker"], str):
+                raise ResultError(f"{field}.speaker must be a string when present")
+        if "words" in segment:
+            _validate_words(segment["words"], f"{field}.words", sample=sample)
+        _validate_bounds(segment, field, sample=sample)
+
+
+def _validate_span_array(
+    values: Sequence[JsonMapping],
+    field: str,
+    expected: set[str],
+    *,
+    sample: bool,
+) -> None:
+    for index, item in enumerate(values):
+        if not isinstance(item, Mapping):
+            raise ResultError(f"{field}[{index}] must be an object")
+        name = f"{field}[{index}]"
+        _exact_keys(item, expected, name)
+        _validate_bounds(item, name, sample=sample)
+        for key in expected - {"start", "end"}:
+            value = item[key]
+            if sample and key not in {"turn_id", "overlap_id"} and value is not None:
+                raise ResultError(f"{name}.{key} placeholder must be null")
+        if field == "turns":
+            if not isinstance(item["turn_id"], str) or not item["turn_id"]:
+                raise ResultError(f"{name}.turn_id must be a non-empty string")
+            if not sample and not isinstance(item["speaker"], str):
+                raise ResultError(f"{name}.speaker must be a string when present")
+        if field == "overlapped_speech":
+            if not isinstance(item["overlap_id"], str) or not item["overlap_id"]:
+                raise ResultError(f"{name}.overlap_id must be a non-empty string")
+        if field == "lid_regions" and not sample:
+            if not isinstance(item["language"], str) or not item["language"]:
+                raise ResultError(f"{name}.language must be a non-empty string")
+            confidence = _number(item["confidence"], f"{name}.confidence")
+            assert confidence is not None
+            if not 0 <= confidence <= 1:
+                raise ResultError(f"{name}.confidence must be between 0 and 1")
+
+
+def _validate_abstentions(
+    values: Sequence[JsonMapping],
+    requested: frozenset[str],
+    *,
+    sample: bool,
+) -> None:
+    for index, item in enumerate(values):
+        if not isinstance(item, Mapping):
+            raise ResultError(f"abstentions[{index}] must be an object")
+        name = f"abstentions[{index}]"
+        _exact_keys(item, {"abstention_id", "reason", "start", "end"}, name)
+        if not isinstance(item["abstention_id"], str) or not item["abstention_id"]:
+            raise ResultError(f"{name}.abstention_id must be a non-empty string")
+        if item["reason"] not in ABSTENTION_REASONS:
+            raise ResultError(
+                f"{name}.reason must be one of {sorted(ABSTENTION_REASONS)}"
+            )
+        if item["reason"] in {"raw_fragment", "short_turn"} \
+                and "diarization" not in requested:
+            raise ResultError(f"{name}.reason {item['reason']!r} requires diarization")
+        if item["reason"] == "overlap" and "overlapped_speech" not in requested:
+            raise ResultError(f"{name}.reason 'overlap' requires overlapped_speech")
+        _validate_bounds(item, name, sample=sample)
+
+
+def _validate_coverage(coverage: JsonMapping, *, duration: float) -> None:
+    _exact_keys(
+        coverage,
+        {
+            "covered_through_seconds",
+            "covered_fraction",
+            "covered_intervals",
+            "missing_intervals",
+            "units_total",
+            "units_completed",
+        },
+        "coverage",
+    )
+    fraction = _number(coverage["covered_fraction"], "coverage.covered_fraction")
+    watermark = _number(
+        coverage["covered_through_seconds"], "coverage.covered_through_seconds"
+    )
+    assert fraction is not None and watermark is not None
+    if not 0 <= fraction <= 1 or not 0 <= watermark <= duration:
+        raise ResultError("coverage fraction and watermark are outside their valid ranges")
+    for key in ("units_total", "units_completed"):
+        value = coverage[key]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ResultError(f"coverage.{key} must be a non-negative integer")
+    if coverage["units_completed"] > coverage["units_total"]:
+        raise ResultError("coverage.units_completed exceeds coverage.units_total")
+    parsed: dict[str, list[tuple[float, float]]] = {}
+    for key in ("covered_intervals", "missing_intervals"):
+        intervals = coverage[key]
+        if not isinstance(intervals, (list, tuple)):
+            raise ResultError(f"coverage.{key} must be an array")
+        parsed[key] = []
+        for index, interval in enumerate(intervals):
+            if not isinstance(interval, (list, tuple)) or len(interval) != 2:
+                raise ResultError(f"coverage.{key}[{index}] must be a [start, end] pair")
+            start = _number(interval[0], f"coverage.{key}[{index}][0]")
+            end = _number(interval[1], f"coverage.{key}[{index}][1]")
+            assert start is not None and end is not None
+            if start < 0 or end <= start or end > duration:
+                raise ResultError(f"coverage.{key}[{index}] is not an ordered interval")
+            parsed[key].append((start, end))
+
+    if duration == 0 or not parsed["missing_intervals"]:
+        raise ResultError("an incomplete result must have non-empty missing intervals")
+    first_missing = min(start for start, _ in parsed["missing_intervals"])
+    if not math.isclose(watermark, first_missing, abs_tol=1e-6):
+        raise ResultError("covered_through_seconds must equal the first missing interval start")
+
+    tiled = sorted(parsed["covered_intervals"] + parsed["missing_intervals"])
+    cursor = 0.0
+    for start, end in tiled:
+        if not math.isclose(start, cursor, abs_tol=1e-6):
+            raise ResultError("covered and missing intervals must tile the source without gaps")
+        cursor = end
+    if not math.isclose(cursor, duration, abs_tol=1e-6):
+        raise ResultError("covered and missing intervals must tile the complete source")
+
+    covered_seconds = sum(end - start for start, end in parsed["covered_intervals"])
+    if not math.isclose(fraction, covered_seconds / duration, abs_tol=0.0005):
+        raise ResultError("covered_fraction must equal covered duration over source duration")
+    if coverage["units_completed"] >= coverage["units_total"]:
+        raise ResultError("an incomplete result must leave at least one unit incomplete")
+
+
+def _validate_observed(observed: Mapping[str, Any], result: NormalizedResult) -> None:
+    allowed = {
+        "stage_wall_seconds",
+        "total_wall_seconds",
+        "peak_rss_bytes_by_stage",
+        "peak_rss_bytes",
+        "peak_mps_live_bytes_by_stage",
+        "peak_mps_live_bytes",
+        "segments",
+        "words",
+        "turns",
+        "segments_without_words",
+        "abstentions",
+        "vad_regions",
+        "lid_regions",
+        "overlapped_speech",
+        "punctuation_invariant_checked",
+        "punctuation_invariant_note",
+    }
+    extra = set(observed) - allowed
+    if extra:
+        raise ResultError(f"provenance.observed carries unknown keys {sorted(extra)}")
+    walls = observed.get("stage_wall_seconds", ABSENT)
+    total_wall = observed.get("total_wall_seconds", ABSENT)
+    if (walls is ABSENT) != (total_wall is ABSENT):
+        raise ResultError(
+            "provenance.observed stage_wall_seconds and total_wall_seconds must appear together"
+        )
+    if walls is not ABSENT:
+        if not isinstance(walls, Mapping) or not walls:
+            raise ResultError("provenance.observed.stage_wall_seconds must be a non-empty object")
+        stage_total = 0.0
+        for stage, value in walls.items():
+            found = _number(value, f"provenance.observed.stage_wall_seconds.{stage}")
+            assert found is not None
+            if found < 0:
+                raise ResultError("stage wall seconds must not be negative")
+            stage_total += found
+        stated = _number(total_wall, "provenance.observed.total_wall_seconds")
+        assert stated is not None
+        if not math.isclose(stage_total, stated, abs_tol=0.005):
+            raise ResultError("total_wall_seconds must equal the sum of stage_wall_seconds")
+
+    for by_stage in ("peak_rss_bytes_by_stage", "peak_mps_live_bytes_by_stage"):
+        total_key = by_stage.removesuffix("_by_stage")
+        peaks = observed.get(by_stage, ABSENT)
+        total_peak = observed.get(total_key, ABSENT)
+        if (peaks is ABSENT) != (total_peak is ABSENT):
+            raise ResultError(f"{by_stage} and {total_key} must appear together")
+        if peaks is ABSENT:
+            continue
+        if not isinstance(peaks, Mapping) or not peaks:
+            raise ResultError(f"provenance.observed.{by_stage} must be a non-empty object")
+        measured = []
+        for stage, value in peaks.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ResultError(f"provenance.observed.{by_stage}.{stage} must be bytes")
+            measured.append(value)
+        if isinstance(total_peak, bool) or not isinstance(total_peak, int):
+            raise ResultError(f"provenance.observed.{total_key} must be bytes")
+        if max(measured) != total_peak:
+            raise ResultError(f"{total_key} must equal the maximum of {by_stage}")
+
+    def count_array(value: OptionalArray) -> int | None:
+        return None if value is ABSENT else len(value)
+
+    expected_counts = {
+        "segments": len(result.segments),
+        "words": sum(len(segment.get("words", [])) for segment in result.segments),
+        "turns": count_array(result.turns),
+        "segments_without_words": sum(
+            1 for segment in result.segments if not segment.get("words")
+        ),
+        "abstentions": len(result.abstentions),
+        "vad_regions": count_array(result.vad_regions),
+        "lid_regions": count_array(result.lid_regions),
+        "overlapped_speech": count_array(result.overlapped_speech),
+    }
+    for key, expected in expected_counts.items():
+        if key not in observed:
+            continue
+        value = observed[key]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ResultError(f"provenance.observed.{key} must be a non-negative integer")
+        if expected is None or value != expected:
+            raise ResultError(
+                f"provenance.observed.{key} is {value}, but the result contains {expected}"
+            )
+
+
+def _validate_provenance(
+    provenance: JsonMapping,
+    requested: frozenset[str],
+    result: NormalizedResult,
+    *,
+    sample: bool,
+) -> None:
+    _exact_keys(provenance, {"stack", "outcomes", "observed", "plan"}, "provenance")
+    if not isinstance(provenance["stack"], str) or not provenance["stack"]:
+        raise ResultError("provenance.stack must be a non-empty string")
+    outcomes = provenance["outcomes"]
+    if not isinstance(outcomes, Mapping):
+        raise ResultError("provenance.outcomes must be an object")
+    if sample:
+        if outcomes:
+            raise ResultError("sample provenance.outcomes must be empty")
+    elif set(outcomes) != requested:
+        raise ResultError("result provenance.outcomes must name every requested capability")
+    for capability, outcome in outcomes.items():
+        if capability not in requested or outcome not in {"produced", "abstained"}:
+            raise ResultError(f"invalid outcome for capability {capability!r}")
+        if capability in {"languages", "verbatim"} and outcome != "produced":
+            raise ResultError(f"{capability} has no abstained output shape")
+    if not isinstance(provenance["observed"], Mapping):
+        raise ResultError("provenance.observed must be an object")
+    _validate_observed(provenance["observed"], result)
+    if not isinstance(provenance["plan"], Mapping):
+        raise ResultError("provenance.plan must be an object")
+
+
+def _reject_non_label_speakers(node: object, field: str = "") -> None:
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            child = f"{field}.{key}" if field else str(key)
+            if key == "speaker" and value == "N/A":
+                raise ResultError(f"{child} must be absent rather than 'N/A'")
+            _reject_non_label_speakers(value, child)
+    elif isinstance(node, (list, tuple)):
+        for index, value in enumerate(node):
+            _reject_non_label_speakers(value, f"{field}[{index}]")
+
+
+def _array(result: NormalizedResult, field: str) -> OptionalArray:
+    return getattr(result, field)
+
+
+def serialize_result(result: NormalizedResult) -> dict[str, Any]:
+    """Validate and return the one JSON-safe normalized result representation."""
+    requested = _capabilities(result.requested_capabilities)
+    if not isinstance(result.complete, bool):
+        raise ResultError("complete must be a boolean")
+    has_coverage = result.coverage is not ABSENT
+    if has_coverage is result.complete:
+        raise ResultError("coverage must be present if and only if complete is false")
+    if has_coverage and not isinstance(result.coverage, Mapping):
+        raise ResultError("coverage must be an object")
+
+    duration = _validate_source(result.source)
+    if has_coverage:
+        assert isinstance(result.coverage, Mapping)
+        _validate_coverage(result.coverage, duration=duration)
+    _validate_segments(result.segments, requested, sample=result.sample)
+    _validate_abstentions(result.abstentions, requested, sample=result.sample)
+    _validate_provenance(result.provenance, requested, result, sample=result.sample)
+
+    arrays = {
+        "turns": ({"turn_id", "speaker", "start", "end"}, result.turns),
+        "vad_regions": ({"start", "end"}, result.vad_regions),
+        "lid_regions": ({"start", "end", "language", "confidence"}, result.lid_regions),
+        "overlapped_speech": ({"overlap_id", "start", "end"}, result.overlapped_speech),
+    }
+    for capability, field in _ARRAY_CAPABILITIES.items():
+        expected_keys, value = arrays[field]
+        present = value is not ABSENT
+        if present != (capability in requested):
+            state = "present" if present else "absent"
+            raise ResultError(
+                f"{field} is {state}, but capability {capability!r} "
+                f"was {'requested' if capability in requested else 'not requested'}"
+            )
+        if present:
+            if not isinstance(value, (list, tuple)):
+                raise ResultError(f"{field} must be an array")
+            _validate_span_array(
+                value, field, expected_keys, sample=result.sample
+            )
+
+    payload: dict[str, Any] = {}
+    if result.sample:
+        if not result.note:
+            raise ResultError("a sample result requires a note")
+        payload.update({"sample": True, "note": result.note})
+    elif result.note is not None:
+        raise ResultError("note is sample metadata and cannot appear on a run result")
+    payload.update({
+        "schema_version": SCHEMA_VERSION,
+        "complete": result.complete,
+        "source": dict(result.source),
+        "segments": [dict(item) for item in result.segments],
+    })
+    for field in ("turns", "vad_regions", "lid_regions", "overlapped_speech"):
+        value = _array(result, field)
+        if value is not ABSENT:
+            payload[field] = [dict(item) for item in value]
+    payload["abstentions"] = [dict(item) for item in result.abstentions]
+    if has_coverage:
+        assert isinstance(result.coverage, Mapping)
+        payload["coverage"] = dict(result.coverage)
+    payload["provenance"] = dict(result.provenance)
+
+    _reject_non_label_speakers(payload)
+    try:
+        return json.loads(json.dumps(payload, ensure_ascii=False, allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise ResultError(f"result is not JSON-safe: {exc}") from exc

--- a/src/audio_cli/transcribe/sample.py
+++ b/src/audio_cli/transcribe/sample.py
@@ -1,0 +1,68 @@
+"""Placeholder results for `audio transcribe plan`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from . import result
+
+SAMPLE_NOTE = "shape only; values are placeholders and cardinality is unknown until run"
+
+
+def build_sample_output(
+    *,
+    source: Mapping[str, Any],
+    stack: str,
+    requested_capabilities: Iterable[str],
+    plan: Mapping[str, Any],
+    abstention_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build a placeholder and send it through the production result serializer."""
+    requested = frozenset(requested_capabilities)
+    segment: dict[str, Any] = {"segment_id": "seg_0", "text": None}
+    if "diarization" in requested:
+        segment["speaker"] = None
+    if "segment_timestamps" in requested:
+        segment.update({"start": None, "end": None})
+    if "word_timestamps" in requested:
+        segment["words"] = [
+            {"word_id": "w_0", "text": None, "start": None, "end": None}
+        ]
+
+    values: dict[str, Any] = {}
+    if "diarization" in requested:
+        values["turns"] = [
+            {"turn_id": "turn_0", "speaker": None, "start": None, "end": None}
+        ]
+    if "vad" in requested:
+        values["vad_regions"] = [{"start": None, "end": None}]
+    if "lid" in requested:
+        values["lid_regions"] = [
+            {"start": None, "end": None, "language": None, "confidence": None}
+        ]
+    if "overlapped_speech" in requested:
+        values["overlapped_speech"] = [
+            {"overlap_id": "overlap_0", "start": None, "end": None}
+        ]
+
+    abstentions = []
+    if abstention_reason is not None:
+        abstentions.append({
+            "abstention_id": "ab_0",
+            "reason": abstention_reason,
+            "start": None,
+            "end": None,
+        })
+
+    placeholder = result.NormalizedResult(
+        source=source,
+        segments=[segment],
+        abstentions=abstentions,
+        provenance={"stack": stack, "outcomes": {}, "observed": {}, "plan": dict(plan)},
+        requested_capabilities=requested,
+        sample=True,
+        note=SAMPLE_NOTE,
+        **values,
+    )
+    return result.serialize_result(placeholder)

--- a/tests/test_transcribe_result.py
+++ b/tests/test_transcribe_result.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from audio_cli.transcribe.result import (
+    ABSENT,
+    ABSTENTION_REASONS,
+    NormalizedResult,
+    ResultError,
+    serialize_result,
+)
+
+
+def base_result(**changes) -> NormalizedResult:
+    found = NormalizedResult(
+        source={"path": "sample.wav", "duration_seconds": 10.0, "timebase": "seconds"},
+        segments=[{"segment_id": "seg_0", "text": "Hello."}],
+        abstentions=[],
+        provenance={"stack": "qwen-1.7b", "outcomes": {}, "observed": {}, "plan": {}},
+        requested_capabilities=frozenset(),
+    )
+    return replace(found, **changes)
+
+
+def test_result_has_the_fixed_floor_shape() -> None:
+    assert serialize_result(base_result()) == {
+        "schema_version": 1,
+        "complete": True,
+        "source": {"path": "sample.wav", "duration_seconds": 10.0, "timebase": "seconds"},
+        "segments": [{"segment_id": "seg_0", "text": "Hello."}],
+        "abstentions": [],
+        "provenance": {"stack": "qwen-1.7b", "outcomes": {}, "observed": {}, "plan": {}},
+    }
+
+
+@pytest.mark.parametrize(
+    ("capability", "field", "value"),
+    [
+        ("diarization", "turns", []),
+        ("vad", "vad_regions", []),
+        ("lid", "lid_regions", []),
+        ("overlapped_speech", "overlapped_speech", []),
+    ],
+)
+def test_top_level_array_exists_iff_its_capability_is_requested(
+    capability: str,
+    field: str,
+    value: list,
+) -> None:
+    with pytest.raises(ResultError, match=field):
+        serialize_result(base_result(**{field: value}))
+    provenance = {
+        "stack": "qwen-1.7b",
+        "outcomes": {capability: "produced"},
+        "observed": {},
+        "plan": {},
+    }
+    with pytest.raises(ResultError, match=field):
+        serialize_result(base_result(
+            requested_capabilities=frozenset({capability}),
+            provenance=provenance,
+        ))
+
+    emitted = serialize_result(base_result(
+        requested_capabilities=frozenset({capability}),
+        provenance=provenance,
+        **{field: value},
+    ))
+    assert field in emitted
+
+
+@pytest.mark.parametrize(
+    ("capability", "keys", "values"),
+    [
+        ("diarization", {"speaker"}, {"speaker": "S1"}),
+        (
+            "word_timestamps",
+            {"words"},
+            {"words": [{"word_id": "w_0", "text": "Hello", "start": 0.0, "end": 1.0}]},
+        ),
+        ("segment_timestamps", {"start", "end"}, {"start": 0.0, "end": 1.0}),
+    ],
+)
+def test_segment_key_is_refused_without_its_capability(
+    capability: str,
+    keys: set[str],
+    values: dict,
+) -> None:
+    segment = {"segment_id": "seg_0", "text": "Hello.", **values}
+    with pytest.raises(ResultError, match=capability):
+        serialize_result(base_result(segments=[segment]))
+
+    kwargs = {
+        "requested_capabilities": frozenset({capability}),
+        "provenance": {
+            "stack": "qwen-1.7b",
+            "outcomes": {capability: "produced"},
+            "observed": {},
+            "plan": {},
+        },
+    }
+    if capability == "diarization":
+        kwargs["turns"] = []
+    emitted = serialize_result(base_result(segments=[segment], **kwargs))
+    assert keys <= set(emitted["segments"][0])
+
+
+def test_languages_and_verbatim_add_no_result_key_and_cannot_abstain() -> None:
+    requested = frozenset({"languages", "verbatim"})
+    result = base_result(
+        requested_capabilities=requested,
+        provenance={
+            "stack": "qwen-1.7b",
+            "outcomes": {"languages": "produced", "verbatim": "produced"},
+            "observed": {},
+            "plan": {},
+        },
+    )
+    emitted = serialize_result(result)
+    assert "languages" not in emitted
+    assert "verbatim" not in emitted
+
+    bad = replace(result, provenance={
+        "stack": "qwen-1.7b",
+        "outcomes": {"languages": "abstained", "verbatim": "produced"},
+        "observed": {},
+        "plan": {},
+    })
+    with pytest.raises(ResultError, match="languages has no abstained"):
+        serialize_result(bad)
+
+
+def test_complete_and_coverage_are_bidirectional() -> None:
+    coverage = {
+        "covered_through_seconds": 4.0,
+        "covered_fraction": 0.4,
+        "covered_intervals": [[0.0, 4.0]],
+        "missing_intervals": [[4.0, 10.0]],
+        "units_total": 2,
+        "units_completed": 1,
+    }
+    with pytest.raises(ResultError, match="if and only if"):
+        serialize_result(base_result(complete=False))
+    with pytest.raises(ResultError, match="if and only if"):
+        serialize_result(base_result(coverage=coverage))
+
+    emitted = serialize_result(base_result(complete=False, coverage=coverage))
+    assert emitted["complete"] is False
+    assert emitted["coverage"] == coverage
+
+
+def test_non_label_speaker_is_rejected_anywhere() -> None:
+    requested = frozenset({"diarization"})
+    provenance = {
+        "stack": "vibevoice",
+        "outcomes": {"diarization": "produced"},
+        "observed": {},
+        "plan": {},
+    }
+    for changes in (
+        {"segments": [{"segment_id": "seg_0", "text": "noise", "speaker": "N/A"}],
+         "turns": []},
+        {"turns": [{"turn_id": "turn_0", "speaker": "N/A", "start": 0.0, "end": 1.0}]},
+    ):
+        with pytest.raises(ResultError, match="must be absent"):
+            serialize_result(base_result(
+                requested_capabilities=requested,
+                provenance=provenance,
+                **changes,
+            ))
+
+
+def test_real_attribution_and_lid_values_are_not_null_placeholders() -> None:
+    diarization = frozenset({"diarization"})
+    with pytest.raises(ResultError, match="speaker must be a string"):
+        serialize_result(base_result(
+            segments=[{"segment_id": "seg_0", "text": "noise", "speaker": None}],
+            turns=[],
+            requested_capabilities=diarization,
+            provenance={
+                "stack": "vibevoice",
+                "outcomes": {"diarization": "produced"},
+                "observed": {},
+                "plan": {},
+            },
+        ))
+
+    lid = frozenset({"lid"})
+    with pytest.raises(ResultError, match="language must be a non-empty string"):
+        serialize_result(base_result(
+            lid_regions=[{"start": 0.0, "end": 1.0, "language": None, "confidence": None}],
+            requested_capabilities=lid,
+            provenance={
+                "stack": "firered",
+                "outcomes": {"lid": "produced"},
+                "observed": {},
+                "plan": {},
+            },
+        ))
+
+
+def test_overlap_id_is_a_non_empty_document_scoped_id() -> None:
+    requested = frozenset({"overlapped_speech"})
+    provenance = {
+        "stack": "qwen-1.7b",
+        "outcomes": {"overlapped_speech": "produced"},
+        "observed": {},
+        "plan": {},
+    }
+    for bad_id in ("", None, 123):
+        with pytest.raises(ResultError, match="overlap_id must be a non-empty string"):
+            serialize_result(base_result(
+                overlapped_speech=[{
+                    "overlap_id": bad_id, "start": 0.0, "end": 1.0,
+                }],
+                requested_capabilities=requested,
+                provenance=provenance,
+            ))
+
+def test_abstention_reason_is_the_closed_recorded_enum() -> None:
+    assert ABSTENTION_REASONS == {"overlap", "short_turn", "raw_fragment"}
+    for reason in ABSTENTION_REASONS:
+        capability = "overlapped_speech" if reason == "overlap" else "diarization"
+        optional = {"overlapped_speech": []} if reason == "overlap" else {"turns": []}
+        emitted = serialize_result(base_result(
+            abstentions=[{
+                "abstention_id": "ab_0", "reason": reason, "start": 0.0, "end": 0.2,
+            }],
+            requested_capabilities=frozenset({capability}),
+            provenance={
+                "stack": "qwen-1.7b",
+                "outcomes": {capability: "produced"},
+                "observed": {},
+                "plan": {},
+            },
+            **optional,
+        ))
+        assert emitted["abstentions"][0]["reason"] == reason
+    with pytest.raises(ResultError, match="reason must be one of"):
+        serialize_result(base_result(abstentions=[{
+            "abstention_id": "ab_0", "reason": "budget", "start": 0.0, "end": 0.2,
+        }]))
+
+
+@pytest.mark.parametrize("reason", sorted(ABSTENTION_REASONS))
+def test_abstention_requires_the_capability_that_can_produce_it(reason: str) -> None:
+    with pytest.raises(ResultError, match="requires"):
+        serialize_result(base_result(abstentions=[{
+            "abstention_id": "ab_0", "reason": reason, "start": 0.0, "end": 0.2,
+        }]))
+
+
+def test_unknown_capability_and_model_specific_keys_are_rejected() -> None:
+    with pytest.raises(ResultError, match="unknown requested"):
+        serialize_result(base_result(requested_capabilities=frozenset({"word_confidence"})))
+    with pytest.raises(ResultError, match="unknown keys"):
+        serialize_result(base_result(segments=[{
+            "segment_id": "seg_0", "text": "Hello.", "asr_confidence": 0.9,
+        }]))
+
+
+def test_globally_unsupported_token_lid_cannot_reach_a_result() -> None:
+    with pytest.raises(ResultError, match="unsupported by every stack"):
+        serialize_result(base_result(requested_capabilities=frozenset({"token_lid"})))
+
+
+def test_run_result_requires_one_outcome_per_requested_capability() -> None:
+    with pytest.raises(ResultError, match="name every requested"):
+        serialize_result(base_result(requested_capabilities=frozenset({"verbatim"})))
+
+
+def test_observed_wall_and_peak_arithmetic_is_enforced() -> None:
+    valid = {
+        "stage_wall_seconds": {"decode": 0.1, "asr": 1.2},
+        "total_wall_seconds": 1.3,
+        "peak_rss_bytes_by_stage": {"asr": 100, "aligner": 80},
+        "peak_rss_bytes": 100,
+    }
+    emitted = serialize_result(replace(
+        base_result(),
+        provenance={"stack": "qwen-1.7b", "outcomes": {}, "observed": valid, "plan": {}},
+    ))
+    assert emitted["provenance"]["observed"] == valid
+
+    for mutation, message in (
+        ({**valid, "total_wall_seconds": 1.4}, "sum of stage"),
+        ({**valid, "peak_rss_bytes": 180}, "maximum"),
+    ):
+        with pytest.raises(ResultError, match=message):
+            serialize_result(replace(
+                base_result(),
+                provenance={
+                    "stack": "qwen-1.7b", "outcomes": {}, "observed": mutation, "plan": {},
+                },
+            ))
+
+
+def test_observed_counts_are_reconciled_with_the_serialized_arrays() -> None:
+    observed = {"segments": 1, "words": 0, "abstentions": 0}
+    emitted = serialize_result(replace(
+        base_result(),
+        provenance={"stack": "qwen-1.7b", "outcomes": {}, "observed": observed, "plan": {}},
+    ))
+    assert emitted["provenance"]["observed"] == observed
+
+    for mutation in (
+        {**observed, "segments": 2},
+        {**observed, "words": 1},
+        {**observed, "turns": 0},
+    ):
+        with pytest.raises(ResultError, match="result contains"):
+            serialize_result(replace(
+                base_result(),
+                provenance={
+                    "stack": "qwen-1.7b", "outcomes": {}, "observed": mutation, "plan": {},
+                },
+            ))
+
+    with pytest.raises(ResultError, match="unknown keys"):
+        serialize_result(replace(
+            base_result(),
+            provenance={
+                "stack": "qwen-1.7b", "outcomes": {},
+                "observed": {"backend_confidence": 0.9}, "plan": {},
+            },
+        ))
+
+
+def test_coverage_cannot_leave_the_source_timeline() -> None:
+    coverage = {
+        "covered_through_seconds": 4.0,
+        "covered_fraction": 0.4,
+        "covered_intervals": [[0.0, 4.0]],
+        "missing_intervals": [[4.0, 11.0]],
+        "units_total": 2,
+        "units_completed": 1,
+    }
+    with pytest.raises(ResultError, match="ordered interval"):
+        serialize_result(base_result(complete=False, coverage=coverage))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ({"covered_through_seconds": 5.0}, "first missing"),
+        ({"covered_fraction": 0.5}, "covered duration"),
+        ({"covered_through_seconds": 5.0, "missing_intervals": [[5.0, 10.0]]},
+         "without gaps"),
+        ({"units_completed": 2}, "leave at least one"),
+    ],
+)
+def test_coverage_ledger_must_be_internally_consistent(
+    mutation: dict[str, object], message: str,
+) -> None:
+    coverage = {
+        "covered_through_seconds": 4.0,
+        "covered_fraction": 0.4,
+        "covered_intervals": [[0.0, 4.0]],
+        "missing_intervals": [[4.0, 10.0]],
+        "units_total": 2,
+        "units_completed": 1,
+        **mutation,
+    }
+    with pytest.raises(ResultError, match=message):
+        serialize_result(base_result(complete=False, coverage=coverage))
+
+
+def test_absent_sentinel_is_not_serialized() -> None:
+    emitted = serialize_result(base_result())
+    assert ABSENT not in emitted.values()

--- a/tests/test_transcribe_sample.py
+++ b/tests/test_transcribe_sample.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from audio_cli.transcribe import sample
+from audio_cli.transcribe.result import CAPABILITY_NAMES, ResultError, serialize_result
+
+SOURCE = {"path": "meeting.m4a", "duration_seconds": 1794.2, "timebase": "seconds"}
+
+
+def build(*capabilities: str) -> dict:
+    return sample.build_sample_output(
+        source=SOURCE,
+        stack="qwen-1.7b",
+        requested_capabilities=capabilities,
+        plan={"roles": {}},
+    )
+
+
+def test_sample_uses_the_production_serializer(monkeypatch) -> None:
+    captured = []
+
+    def recording_serializer(value):
+        captured.append(value)
+        return {"through": "serializer"}
+
+    monkeypatch.setattr(sample.result, "serialize_result", recording_serializer)
+    assert build("diarization") == {"through": "serializer"}
+    assert len(captured) == 1
+    assert captured[0].sample is True
+
+
+@pytest.mark.parametrize("capability", sorted(CAPABILITY_NAMES - {"token_lid"}))
+def test_each_capability_produces_exactly_its_licensed_shape(capability: str) -> None:
+    baseline = build()
+    emitted = build(capability)
+    added = set(emitted) - set(baseline)
+    expected = {
+        "diarization": {"turns"},
+        "overlapped_speech": {"overlapped_speech"},
+        "vad": {"vad_regions"},
+        "lid": {"lid_regions"},
+    }.get(capability, set())
+    assert added == expected
+
+    segment_added = set(emitted["segments"][0]) - set(baseline["segments"][0])
+    segment_expected = {
+        "diarization": {"speaker"},
+        "word_timestamps": {"words"},
+        "segment_timestamps": {"start", "end"},
+    }.get(capability, set())
+    assert segment_added == segment_expected
+
+
+def test_combined_sample_contains_every_requested_shape_once() -> None:
+    capabilities = (
+        "languages", "verbatim", "diarization", "overlapped_speech", "vad",
+        "word_timestamps", "segment_timestamps", "lid",
+    )
+    emitted = sample.build_sample_output(
+        source=SOURCE,
+        stack="qwen-1.7b",
+        requested_capabilities=capabilities,
+        plan={"roles": {}},
+        abstention_reason="raw_fragment",
+    )
+    assert set(emitted) == {
+        "sample", "note", "schema_version", "complete", "source", "segments", "turns",
+        "vad_regions", "lid_regions", "overlapped_speech", "abstentions", "provenance",
+    }
+    assert emitted["complete"] is True
+    assert emitted["source"] == SOURCE
+    assert emitted["provenance"] == {
+        "stack": "qwen-1.7b", "outcomes": {}, "observed": {}, "plan": {"roles": {}},
+    }
+    assert len(emitted["abstentions"]) == 1
+    assert emitted["abstentions"][0]["reason"] == "raw_fragment"
+    assert emitted["overlapped_speech"][0]["overlap_id"] == "overlap_0"
+
+
+def test_placeholder_has_null_content_and_bounds_not_plausible_values() -> None:
+    emitted = build("diarization", "word_timestamps", "segment_timestamps", "lid")
+    segment = emitted["segments"][0]
+    assert segment["text"] is None
+    assert segment["speaker"] is None
+    assert segment["start"] is None and segment["end"] is None
+    assert segment["words"][0]["text"] is None
+    assert segment["words"][0]["start"] is None
+    assert emitted["lid_regions"][0]["confidence"] is None
+
+
+def test_serializer_rejects_mutated_placeholder_content_and_zero_bound() -> None:
+    original = sample.result.NormalizedResult(
+        source=SOURCE,
+        segments=[{"segment_id": "seg_0", "text": None, "start": None, "end": None}],
+        abstentions=[{
+            "abstention_id": "ab_0", "reason": "raw_fragment", "start": None, "end": None,
+        }],
+        provenance={"stack": "firered", "outcomes": {}, "observed": {}, "plan": {}},
+        requested_capabilities=frozenset({"segment_timestamps", "diarization"}),
+        turns=[],
+        sample=True,
+        note=sample.SAMPLE_NOTE,
+    )
+    with pytest.raises(ResultError, match="text placeholder must be null"):
+        serialize_result(replace(
+            original,
+            segments=[{"segment_id": "seg_0", "text": "placeholder", "start": None,
+                       "end": None}],
+        ))
+    with pytest.raises(ResultError, match="placeholder bounds must be null"):
+        serialize_result(replace(
+            original,
+            segments=[{"segment_id": "seg_0", "text": None, "start": 0.0, "end": 0.0}],
+        ))
+
+
+def test_sample_rejects_an_unknown_capability() -> None:
+    with pytest.raises(ResultError, match="unknown requested"):
+        build("speaker_attribution")
+
+
+def test_sample_rejects_the_globally_unsupported_capability() -> None:
+    with pytest.raises(ResultError, match="unsupported by every stack"):
+        build("token_lid")
+
+
+def test_sample_does_not_fabricate_stack_specific_abstentions() -> None:
+    assert build("diarization")["abstentions"] == []
+    assert build("overlapped_speech")["abstentions"] == []


### PR DESCRIPTION
## Summary
- add the normalized transcription result model and single JSON-safe serializer
- enforce capability-gated absence, partial-result coverage consistency, provenance arithmetic, and document-scoped identities
- generate plan samples through the same production serializer with explicit null placeholders

## Verification
- `uv run --extra dev pytest -q` (235 passed)
- `uv run python -m compileall -q src tests`
- `git diff --cached --check`
- three adversarial Claude review passes; final verdict: `NO ACTIONABLE FINDINGS`

Closes #19