### PR TITLE
Implement Qwen transcription execution

### DIFF
--- a/.agents/skills/audio-cli/SKILL.md
+++ b/.agents/skills/audio-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audio-cli
-description: Do audio work on local media with the `audio` CLI — diagnose what is wrong with a recording, clean up and level speech in a video or podcast, render an ASR-ready proxy before transcribing, apply an evidence-backed fix to one region or one frequency, and provision the local models transcription needs. Use this whenever someone wants audio measured, cleaned up, made clearer or more consistent, or prepared for transcription, even if they never mention this CLI, a profile, or a model — every result comes back as JSON you can act on, and the failure modes here are the kind that produce confident wrong answers.
+description: Do audio work on local media with the `audio` CLI — diagnose what is wrong with a recording, clean up and level speech in a video or podcast, render an ASR-ready proxy, transcribe through a local Qwen stack, apply an evidence-backed targeted fix, and provision the models each request needs. Use this whenever someone wants audio measured, cleaned up, made clearer or more consistent, prepared for transcription, or transcribed, even if they never mention this CLI, a profile, or a model — results come back as structured data you can act on, and the failure modes here are the kind that produce confident wrong answers.
 ---
 
 # Audio work with the `audio` CLI
@@ -33,7 +33,8 @@ checkout of this repository, where `uv run audio ...` works from the root withou
 | "fix / clean up / level this recording or video" | inspect, resolve, render, verify | [references/enhance-audio.md](references/enhance-audio.md) |
 | "get this ready for transcription" | the same loop, transcription profile | [references/enhance-audio.md](references/enhance-audio.md) |
 | "this part is too quiet", "there's a hum at 60 Hz" | a scoped gain, authorized by evidence | [references/targeted-fixes.md](references/targeted-fixes.md) |
-| "transcribe this", "what will this download?" | provision models explicitly | [references/model-packages.md](references/model-packages.md) |
+| "transcribe this" | choose capabilities, plan, provision, run | [references/transcribe.md](references/transcribe.md) |
+| "what will this download?" | inspect and provision models explicitly | [references/model-packages.md](references/model-packages.md) |
 | "free up disk", or a command reports something missing | check state, then pull, repair, or reclaim | [references/model-packages.md](references/model-packages.md) |
 | the command is missing or will not run | install and verify | [references/install.md](references/install.md) |
 
@@ -47,8 +48,9 @@ has a way of producing a plausible wrong answer that `--help` cannot warn you ab
   measuring a measurement.
 - **Absence is meaningful.** A field the tool did not supply stays absent rather than becoming a
   null, a zero, or a default that reads like a measurement. Never fill one in when relaying results.
-- **stdout JSON belongs to the caller.** Pass it through unchanged and put interpretation in your
-  reply, not in the payload.
+- **Machine output belongs to the caller.** JSON is the default and must pass through unchanged;
+  put interpretation in your reply, not in the payload. Human transcript formats appear only when
+  the caller explicitly requests one.
 
 ## The honest limits
 
@@ -62,10 +64,12 @@ These are the four claims that get made wrongly. Knowing them is most of the ski
 - **Overlapping sources in one mixed track cannot be separated.** Gain and EQ move speech and music
   together when they overlap in time. Preserve the source or abstain; never imply independent
   control you do not have.
-- **Models arrive only when explicitly pulled, and there is no transcription command yet.**
-  Provisioning ships ahead of it, so never describe `audio transcribe` as runnable, and never
-  hand-download weights or hand-build an environment to work around a missing package.
+- **Models arrive only when explicitly pulled, and only the Qwen run adapters ship today.**
+  Capability discovery and planning cover all four stack ids, but FireRed and VibeVoice execution
+  remain work in progress. Never hand-download weights or hand-build an environment to work around
+  a missing package.
 
-When a command fails, it prints one JSON error object on stderr. If that object carries a `fix`,
-run that string verbatim — it is the tool naming its own remedy, and improvising instead is how one
-problem becomes two.
+When a command fails, its final stderr item is one JSON error object; `transcribe run` may stream
+plain-text progress before it. Parse the final object. If `fix` begins with `audio`, run that command
+verbatim; otherwise no working command exists, so report the sentence as the blocker instead of
+retrying blindly.

--- a/.agents/skills/audio-cli/references/model-packages.md
+++ b/.agents/skills/audio-cli/references/model-packages.md
@@ -1,10 +1,8 @@
 # Provisioning the models transcription needs
 
-The lane for *"transcribe this"*, *"what will this download?"*, and *"reclaim that disk"*.
-
-**The command that will use these models does not exist yet.** Provisioning shipped ahead of it, so
-today this lane is for getting a machine ready, reporting what a request would cost, and cleaning up
-— not for producing a transcript. Never describe `audio transcribe` as something someone can run.
+The lane for *"what will this download?"*, *"prepare this transcription stack"*, and *"reclaim
+that disk"*. For producing a transcript, read [transcribe.md](transcribe.md) first; only the two
+Qwen run adapters ship today.
 
 ## Nothing downloads itself
 

--- a/.agents/skills/audio-cli/references/transcribe.md
+++ b/.agents/skills/audio-cli/references/transcribe.md
@@ -1,0 +1,31 @@
+# Transcribe local media
+
+Start by deciding what the result must contain, not by asking for every capability. Omitting
+`--want` is the small floors-only transcript; diarization adds anonymous speaker labels and turns,
+word timestamps add the aligner, overlap detection adds overlap intervals, and VAD adds activity
+regions. The abstention ledger is a floor and survives whenever a selected backend excludes a
+span, independent of optional result arrays. Each addition changes packages or work, so use `capabilities` when the choice is unclear
+and `plan` when it is already known.
+
+The stack is a quality decision. The two executable stacks today are `qwen-1.7b` and
+`qwen-0.6b`: they resolve the same capabilities, while recorded Cantonese fidelity separates them.
+Do not choose the smaller stack merely because it is available, and do not claim the catalog's
+fixture-specific figures apply to new media. FireRed and VibeVoice can be inspected and planned but
+their run adapters have not shipped.
+
+Planning never provisions. Read the plan's package list and warnings, then run its explicit pull
+command if needed. A run will fail at exit 3 before decode or model load when a required package is
+absent or unusable. Follow the JSON `fix`; never download weights or create a runtime by hand.
+
+The original input remains canonical. The command decodes a temporary working WAV, keeps published
+bounds on the source timeline, and never promotes processing-container bounds into speech timing.
+An absent key is evidence that the capability was not produced, not a blank to fill. Speaker labels
+are anonymous and must not be mapped to people or roles without separate evidence.
+
+Exit 4 is usable but incomplete: a conforming partial JSON document was written and the error's
+`coverage` object says exactly which source intervals remain. Run its `--range` fix against the
+original input. Keep both documents; deterministic merging and subtitle export are not shipped yet.
+
+Interpret the result in your reply. Preserve the JSON output unchanged when another agent or tool
+will dispatch on it, and distinguish what the backend produced from any inference you make from the
+text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Working in this repository
 
 A local-first `audio` CLI for agent workflows: measure audio, enhance it deterministically,
-provision the model packages and runtimes transcription will need, and (in progress) transcribe it.
-`inspect`, `enhance`, `doctor`, and `packages` ship; `transcribe` does not exist yet. Every command
-prints JSON on stdout for a caller to dispatch on; prose interpretation belongs in your reply, not
-in the payload.
+provision model packages and runtimes, and transcribe through explicit stacks. `inspect`, `enhance`,
+`doctor`, and `packages` ship; `transcribe capabilities` and `transcribe plan` cover all four stack
+ids, while `transcribe run` currently executes the two Qwen stacks. FireRed, VibeVoice, and export
+are issues #22–#24. JSON is the machine-readable result format; prose interpretation belongs in
+your reply, not in the payload.
 
 ## The rule that matters most
 
@@ -45,7 +46,7 @@ the commands that already exist — `doctor`, `packages list`, `packages verify`
 real stdout against TRANSCRIBE_HAPPY_PATH.md, key set and nesting rather than values. All three
 had drifted when it was written. Where the documents disagree with each other it abstains and
 names the dispute instead of ratifying a side; the open one is the shape of `failed[]`, recorded
-in HANDOFF.md. Add a shipped command to it when you ship one.
+in HANDOFF.md. Add every newly shipped stack's `run` shape when its adapter lands.
 
 ## Evidence conventions
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,9 @@
 # Agent handoff
 
-Updated 2026-08-18. This repository currently has a production-oriented audio
-enhancement CLI and a completed ASR research/distillation phase. The next phase
-is to turn the ASR decisions into a transcription CLI where the caller picks a
-stack and states requirements, plus its associated agent skill.
+Updated 2026-09-03. This repository has a production-oriented audio enhancement CLI,
+explicit model provisioning, transcription capability discovery and planning, and the first
+executable transcription stacks. Phase C in issue #21 runs `qwen-1.7b` and `qwen-0.6b`; the
+remaining direct sequence is FireRed (#22), VibeVoice (#23), then export (#24).
 
 ## Current state
 
@@ -57,7 +57,21 @@ stack and states requirements, plus its associated agent skill.
 - The benchmark harness, manifests, compact results, and controlled research
   record live under `model_tests/`. Raw media, downloaded model weights, and
   local run directories are intentionally ignored.
-- No transcription command or ASR backend abstraction has been implemented yet.
+- `audio transcribe capabilities` and `audio transcribe plan` ship for all four stack ids.
+  `audio transcribe run` ships for `qwen-1.7b` and `qwen-0.6b`. It uses one canonical temporary
+  PCM WAV, strictly sequential fresh MLX/Swift processes, core-side adapters, exact anonymous-turn
+  reconciliation, optional in-process Silero VAD, per-segment MLX alignment, exit-3 package
+  preflight, and exit-4 partial/resume coverage. FireRed and VibeVoice remain deliberately
+  unimplemented behind the same transport boundary.
+- Issue #21's release candidate is on `codex/issue-21`, based directly on
+  `2e4e85662e24e4f6a6754de7a40d8f1cdd6c10f2` (`origin/main` when the branch was cut). Final
+  verification collected and passed 408 tests; the targeted Ruff gate and `git diff --check`
+  passed; `audio packages verify` reported all four environments `ok` with the pinned MLX private
+  API hash and signature matching; a fresh floors-only Qwen 0.6B run produced 23 chronological
+  segments over the canonical 139.284-second fixture timeline; and a fresh sdist/wheel build
+  contained the environment stage scripts, core adapters, and shipped audio skill references.
+  Claude reviewed the full staged diff adversarially through twelve numbered passes (one hung pass
+  was discarded and rerun) and the terminal review returned exactly `CONVERGED`.
 - [VOCABULARY.md](VOCABULARY.md) settles the naming contract for that work:
   stack, role, backend, add-on, package, environment, capability, satisfaction,
   availability, evidence, plan, policy, and the floors that are never optional.
@@ -65,11 +79,46 @@ stack and states requirements, plus its associated agent skill.
 - [TRANSCRIBE_CONTRACT.md](TRANSCRIBE_CONTRACT.md) is the command surface that contract
   must produce, end to end for all four stack ids including teardown, and
   [TRANSCRIBE_HAPPY_PATH.md](TRANSCRIBE_HAPPY_PATH.md) is the unabridged expected output per
-  use case plus all twelve refusals. Both are signed off; none of it is built.
-- [TRANSCRIBE_DESIGN_HANDOFF.md](TRANSCRIBE_DESIGN_HANDOFF.md) is where the next phase starts:
-  what is decided, what is open design work, the risks worst-first, and a suggested build
-  order. Read it before designing anything under `src/`.
+  use case plus all refusals. Both are signed off; implementation is complete through phase C.
+- [TRANSCRIBE_IMPLEMENTATION_PLAN.md](TRANSCRIBE_IMPLEMENTATION_PLAN.md) owns the remaining phase
+  boundaries. [TRANSCRIBE_DESIGN_HANDOFF.md](TRANSCRIBE_DESIGN_HANDOFF.md) is the historical design
+  record and still explains the risks and rejected alternatives.
 - `tests/test_spec_docs.py` holds the spec documents' invariants and runs in the normal suite.
+
+## Next agent: issues #22–#24
+
+Start only after issue #21's PR is merged, from a fresh branch based on the resulting
+`origin/main`. Do not carry the Phase C worktree or stack these phases on an unmerged local
+commit. The shared seam is now concrete:
+
+- Core orchestration is in `src/audio_cli/transcribe/orchestrator.py`; fresh-process invocation
+  and request/result JSON ownership are in `transport.py`.
+- Environment entry points under `transcribe/stages/` import no `audio_cli`. Backend-specific
+  objects and raw defaults stop at `transcribe/adapters/`; the normalized serializer remains the
+  only public result path.
+- `audio transcribe run --stack firered` and `--stack vibevoice` currently refuse without loading
+  a model. Replace only the matching refusal when its adapter lands.
+- Add every shipped `run` shape to `tests/test_shipped_commands_match_the_document.py`. Keep exit
+  3 before transport, exit 4 only when a conforming partial exists, and `peak_*` totals as maxima
+  across sequential stages.
+
+Issue #22 is next because FireRed exercises one co-resident stage process containing native VAD,
+optional LID, ASR, and punctuation. Its word objects have exactly `start_ms`, `end_ms`, and `text`;
+do not reintroduce per-word confidence from summaries. Assert the punctuation invariant per
+sentence, group LID at VAD-region granularity, and omit the backend's default-filled language
+fields when LID was not requested.
+
+Issue #23 then adds VibeVoice. Preserve complete segments from truncated raw text before exit 4,
+drop both literal `"N/A"` and absent speakers rather than turning either into an identity, and
+retain bounded non-speech event segments without a fabricated word stream.
+
+Issue #24 is deterministic post-processing only: SRT, VTT, Markdown, text, and JSONL; merge
+partial/resumed documents in source order and re-id them; refuse subtitle output without real
+word timing; never derive a cue from a processing-unit or segment container bound.
+
+For each issue, keep the established `plan -> implement -> verify -> adversarial review -> PR`
+loop. The acceptance text in the issue body is the checklist; backend claims must be checked
+against the named runner or recorded artifact, not this handoff.
 
 ## Read this first
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -63,7 +63,8 @@ remaining direct sequence is FireRed (#22), VibeVoice (#23), then export (#24).
   reconciliation, optional in-process Silero VAD, per-segment MLX alignment, exit-3 package
   preflight, and exit-4 partial/resume coverage. FireRed and VibeVoice remain deliberately
   unimplemented behind the same transport boundary.
-- Issue #21's release candidate is on `codex/issue-21`, based directly on
+- Issue #21's release candidate is [PR #29](https://github.com/fyang0507/audio-processing-cli/pull/29)
+  on `codex/issue-21`, based directly on
   `2e4e85662e24e4f6a6754de7a40d8f1cdd6c10f2` (`origin/main` when the branch was cut). Final
   verification collected and passed 408 tests; the targeted Ruff gate and `git diff --check`
   passed; `audio packages verify` reported all four environments `ok` with the pinned MLX private

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ original + profile
 
 The CLI reports what it measured, which versioned rule matched, the exact DSP parameters it resolved, and whether the result conforms to the selected profile. It does not label audio universally “good” or “bad,” and it abstains where a mixed track cannot be changed safely.
 
-The second implemented surface is provisioning: `audio doctor` reports what the machine supplies, and `audio packages` installs, verifies, and reclaims the pinned model packages and runtimes that transcription will need. It is described under [Model packages](#model-packages). There is no `transcribe` command yet — provisioning shipped ahead of it deliberately, so nothing downloads a model behind a caller's back.
+The second implemented surface is transcription and its explicit provisioning layer.
+`audio transcribe capabilities` describes a stack, `audio transcribe plan` resolves an exact
+request, and `audio transcribe run` executes the `qwen-1.7b` and `qwen-0.6b` stacks. `audio
+doctor` reports what the machine supplies, and `audio packages` installs, verifies, and reclaims
+the pinned packages and runtimes. FireRed, VibeVoice, and deterministic export remain the next
+three implementation phases; the command never downloads a model behind a caller's back.
 
 This implements [Issue #4 — Profile-driven automatic audio enhancement](https://github.com/fyang0507/audio-processing-cli/issues/4) within the product boundary established by [Issue #1](https://github.com/fyang0507/audio-processing-cli/issues/1).
 
@@ -180,12 +185,43 @@ audio packages purge --dry-run          # what a teardown would reclaim, reclaim
 
 Six behaviours to know before dispatching on the payloads:
 
-- `pull` accepts package ids **or** `--stack`, never both, and it refuses `--want` at exit 2 rather than accepting a capability filter it cannot honour until the planner lands.
+- `pull` accepts package ids **or** `--stack`, never both, and it refuses `--want` at exit 2 rather than accepting a capability filter it does not implement. Use `transcribe plan` to find the exact package set, then pull those ids, or pull the complete stack.
 - A package the registry already calls `ready` is reported under `skipped` and not re-materialized; it contributes nothing to `pulled_known_bytes`. `pull --repair PACKAGE` forces the work anyway, re-downloading a Hub snapshot and re-cloning a checkout rather than trusting what is on disk.
 - `--stack` tolerates a package its toolchain blocks: the rest of the stack provisions, the exit stays 0, and the blocked package appears in `warnings` with `blocking: true`. Naming that package on the command line is an instruction rather than a guess, so there an absent toolchain is exit 3.
 - `verify` publishes one verdict per environment — `ok`, `drifted`, `blocked`, or `absent`. Only `drifted` is repairable here, with `verify --repair`. `blocked` means a tool the environment requires is off `PATH`, so nothing in it can run; it exits 0 and says so rather than naming a fix this CLI cannot perform.
 - `digest: "ok"` is published only for a package pinned by content hash, which is `silero-vad` and nothing else. Hub packages publish the `revision` they pinned — a different claim, deliberately a different key.
 - `remove` resolves every name against the registry before deleting anything, and both teardowns drop a registry entry as that package's own bytes go. Weights live in a Hub cache shared with other tools, so a revision this root downloaded is deleted and one that pre-existed is retained; `purge --dry-run` reports the split before a caller promises a total.
+
+## Transcription
+
+The stack is an explicit quality choice. Inspect its capabilities, resolve the packages and
+stages for one request, provision what the plan names, then run:
+
+```bash
+audio transcribe capabilities --input meeting.m4a --stack qwen-1.7b
+audio transcribe plan --input meeting.m4a --stack qwen-1.7b \
+  --want diarization,word_timestamps
+audio packages pull --stack qwen-1.7b
+audio transcribe run --input meeting.m4a --stack qwen-1.7b \
+  --want diarization,word_timestamps --language Cantonese \
+  --format json -o meeting.timed.json
+```
+
+Existing transcript and partial-result paths are preserved unless `--force` is explicit; no flag
+can make the output overwrite the canonical input.
+
+The Qwen runner decodes one temporary mono 16 kHz PCM WAV while preserving the original source,
+runs model stages strictly sequentially in fresh processes, and keeps every result bound on the
+source timeline. Derived diarization uses anonymous FluidAudio labels; overlap, sub-250 ms raw
+fragments, and sub-500 ms turns are recorded as abstentions rather than transcribed twice or
+silently discarded. A generation-budget stop writes a conforming partial JSON document at exit
+4; its refusal supplies an `audio transcribe run --range START:` command that re-decodes and
+re-diarizes the whole source before processing only intersecting units.
+
+Omitting `--want` is the floors-only request, not “everything.” `--language` is an optional closed
+Qwen hint and does not reach the forced aligner. Missing packages fail at exit 3 with an explicit
+`audio packages pull` fix before decode or model load. `firered` and `vibevoice` can already be
+inspected and planned, but their `run` adapters are tracked in issues #22 and #23; export is #24.
 
 ## Test
 

--- a/TRANSCRIBE_CONTRACT.md
+++ b/TRANSCRIBE_CONTRACT.md
@@ -1,9 +1,10 @@
 # `transcribe` command contract
 
-**Status: specification.** None of the commands below are implemented yet. This
-is the agent-facing sequence the v1 transcription work must produce, written end
-to end for all four v1 stack ids: from a machine with nothing installed, through
-provisioning and execution and export, to teardown. Terms are defined in
+**Status: implemented through phase C.** `capabilities` and `plan` work for all four stack ids,
+and `run` executes `qwen-1.7b` and `qwen-0.6b`. FireRed, VibeVoice, and `export` remain phases D,
+E, and F in issues #22–#24. This is the agent-facing sequence the complete v1 transcription
+surface must produce: from a machine with nothing installed, through provisioning and execution
+and export, to teardown. Terms are defined in
 [VOCABULARY.md](VOCABULARY.md); the backend evidence is in
 [model_tests/DECISION_REPORT.md](model_tests/DECISION_REPORT.md).
 
@@ -39,13 +40,13 @@ as the simplest command. The deviation is deliberate.
 | --- | --- |
 | 0 | Success. |
 | 1 | Runtime or backend failure with nothing salvageable. No result is written. Distinct from a principled abstention, which is a successful run. |
-| 2 | Request or validation error: missing stack or input, unknown capability, a capability the chosen stack cannot satisfy, an option the stack does not accept, a pin that conflicts with a requirement, absent word timing on export. |
+| 2 | Request or validation error: missing stack or input, unknown capability, a capability the chosen stack cannot satisfy, an option the stack does not accept, a pin that conflicts with a requirement, an unsafe output destination, absent word timing on export. |
 | 3 | A required package is not provisioned, or a provisioned one failed its integrity check. Only `run` can return these. |
-| 4 | Incomplete: some units were transcribed and some were not. A partial result **is** written, with a coverage ledger and a resume command. Only `run` can return this, and only on a stack whose work is partitioned. |
+| 4 | Incomplete: zero or more units were transcribed and at least one remains. A partial result **is** written, with a coverage ledger and a resume command. Only `run` can return this, and only on a stack whose work is partitioned. |
 
-Every error payload carries `code` and `fix`. **`fix` is a runnable command wherever a
-configuration exists that would work**, so a caller can copy one line and be right on the next
-attempt; where nothing would work it is a sentence saying so and naming the nearest available
+Every error payload carries `code` and `fix`. **`fix` is a runnable command wherever the current
+request can be repaired without inventing a caller-owned path**, so a caller can copy one line and
+be right on the next attempt; otherwise it is a sentence naming the decision or nearest available
 output. Emitting a plausible command that fails again is worse than admitting there is none.
 The remaining fields are fixed per code, and this table is the contract — a payload with a
 field not listed for its code, or missing one that is, is a defect:
@@ -60,6 +61,10 @@ field not listed for its code, or missing one that is, is a defect:
 | `capability_unsatisfiable_on_stack` | 2 | `capability`, `allowed` (non-empty), `available_on_stack` |
 | `capability_unsupported` | 2 | `capability`, `allowed` (empty), `reason` |
 | `pin_conflicts_with_native_capability` | 2 | `field`, `provided`, `allowed`, `capability` |
+| `range_invalid` | 2 | `field`, `provided`, `reason` |
+| `stack_run_unavailable` | 2 | `stack`, `issue` |
+| `output_exists` | 2 | `field`, `provided`, `existing` |
+| `output_is_canonical_input` | 2 | `field`, `provided`, `resolved_target` |
 | `timing_required_for_format` | 2 | `field`, `provided`, `requires_capability`, `found`, `note` |
 | `packages_not_provisioned` | 3 | `missing`, `total_known_download_bytes`, `unsized_packages` |
 | `package_integrity_failed` | 3 | `failed` (package, check, expected, actual) |
@@ -90,6 +95,10 @@ array, which is a stdout field of the plan document, not a stderr message.
 
 `run` defaults to `--format json` on stdout, matching the existing CLI's
 machine-readable convention. `--format md|txt` are for human consumption.
+An existing explicit output or its derived partial-result path is refused before decode unless
+`--force` is present. When `-o` is omitted, incomplete runs choose an unused sibling partial path
+instead of replacing an earlier attempt. Even with `--force`, `--output` may never resolve to the
+canonical input.
 
 `--language` is the one caller-settable model input, and it is a hint passed to the
 ASR rather than a capability. Only the Qwen stacks accept it; `vibevoice` advertises
@@ -374,8 +383,8 @@ Exits 0 whether or not anything is provisioned:
     "diarizer":   {"backend": "fluidaudio", "version": "0.15.5",
                    "revision": "19600a485baa4998812e4654b70d2bab8f2c9949",
                    "environment": "swift",
-                   "config": {"preset": "quality", "step_ratio": 0.1,
-                              "min_segment_duration": 0.0, "output": "regular",
+                   "config": {"step_ratio": 0.1,
+                              "min_segment_duration": 0.0,
                               "threshold": 0.6, "batch_size": 32},
                    "config_note": "the shipped default supplies no speaker-count prior and enables overlapping_segments only when overlapped_speech is requested; the cited quality figures used both --num-speakers 2 and --overlapping-segments, so they do not measure this request",
                    "selected_by": "add_on_required_by:diarization"}
@@ -448,6 +457,10 @@ overlap-permitting output. Whether it fills depends on the audio.
 stubbing what it already knows. The value `1794.2` is illustrative — this document
 has no real `meeting.m4a` — and is deliberately not the 30-minute reference fixture behind
 the `capabilities` report's `cost.proved`, which describes a recorded run rather than this input.
+On `run`, the same source-audio duration is recomputed from the canonical decode's PCM frame
+count so range and coverage arithmetic use the timeline actually processed. `source.path` still
+names the original media, and `source` publishes no temporary format, sample-rate, or channel
+fields; the working WAV remains an unpublished transport artifact.
 
 There is no `measured` block here, and there was one. It restated the `capabilities` report's timing and
 memory figures inside every plan, which duplicated the one place those figures belong now
@@ -480,6 +493,13 @@ stage walls and the maximum of the stage peaks, not the sum of both; and strict
 sequencing is load-bearing for the memory story rather than an implementation detail,
 because `vibevoice` at 20.28 GiB and the aligner have never been measured resident at
 the same time and nothing here should imply they can be.
+
+Each RSS cell is the total resident footprint of the process executing that stage, including
+its runtime and orchestration overhead; it is not allocation attributed only to the backend.
+The in-process VAD cell is the core process high-water mark observed through that stage, while
+fresh model and Swift stage cells measure those child processes. `peak_mps_live_bytes_by_stage`
+is different: it is the MLX allocator's live-device-memory high-water mark inside each MLX
+stage, excludes ordinary RSS and non-MLX processes, and is also aggregated with `max`, never sum.
 
 ### 1.2 What `run` does with packages absent
 
@@ -1037,6 +1057,29 @@ Exit 2, `code: "pin_conflicts_with_native_capability"`, `field: "--diarizer"`,
 `vibevoice` satisfies it natively and no diarizer role exists in this plan. Pins
 select among implementations of a role the plan actually contains.
 
+A malformed or nonintersecting resume range is a request error, not an FFmpeg failure:
+
+```json
+{
+  "code": "range_invalid",
+  "field": "--range",
+  "provided": "400:",
+  "reason": "range does not intersect the source duration",
+  "fix": "audio transcribe run --input demo.mp4 --stack qwen-0.6b"
+}
+```
+
+A stack whose execution adapter has not shipped is also refused before media or package work:
+
+```json
+{
+  "code": "stack_run_unavailable",
+  "stack": "firered",
+  "issue": 22,
+  "fix": "the firered run adapter is tracked in https://github.com/fyang0507/audio-processing-cli/issues/22"
+}
+```
+
 A backend crash is the one failure that is not a refusal:
 
 ```json
@@ -1071,8 +1114,9 @@ Exit 3, and nothing loads. `run` does not hash multi-gigabyte weights on every
 invocation; it checks presence and the registry, so this surfaces either from an explicit
 `audio packages verify` or from the cheap check catching a size or revision mismatch. A
 corruption subtle enough to pass the cheap check fails at model load instead, which is
-`backend_failed` at exit 1 with `fix` pointing at `audio packages verify` — the same
-condition, found later, reported as what it looked like from where it was found.
+`backend_failed` at exit 1. Its `fix` is deliberately a sentence directing the caller to the
+reported runtime condition; a package verification command can legitimately print `ok` after
+an OOM or backend abort and therefore cannot be advertised as a repair.
 
 A built package has a fourth failure of its own: the build succeeded and the executable it
 produced does not launch.
@@ -1100,8 +1144,9 @@ recording `product_runs: false` and exiting 0.
 Long-form transcription has partial-completion mechanisms that are real and recorded, not
 hypothetical. Two are visible in the harness today:
 
-- **The Qwen path carries a global generation budget** and stops when it runs out, keeping
-  the turns it finished. The recorded runner tracks `input_turns`, `processed_turns`, and
+- **The Qwen path carries a global generation budget** and stops when it runs out. The stage
+  records every turn it finished; the partial document retains the longest chronological prefix
+  so its resume is disjoint. The recorded runner tracks `input_turns`, `processed_turns`, and
   `unprocessed_turns`, and every recorded run has `unprocessed_turns: []` — but the
   60-minute stress run consumed 10,169 of 16,384 tokens, so at that token rate the budget
   exhausts somewhere near **1.6 hours** of comparable material. A three-hour interview
@@ -1124,6 +1169,7 @@ incomplete run writes its result and exits 4 rather than throwing the work away:
   "backend": "qwen3-asr-1.7b-8bit",
   "detail": "global generation budget exhausted after 148 of 195 turns",
   "coverage": {
+    "scope_intervals": [[0.0, 1794.2]],
     "covered_through_seconds": 1402.88,
     "covered_fraction": 0.782,
     "covered_intervals": [[0.0, 1402.88]],
@@ -1138,13 +1184,19 @@ incomplete run writes its result and exits 4 rather than throwing the work away:
 
 Four properties that matter more than the shape.
 
+`scope_intervals` records the source-timeline extent this invocation selected. It is the whole
+source for an ordinary run and the complete processing-unit span selected by `--range` for a
+resumed run. Covered and missing intervals partition that scope exactly; material outside it is
+neither claimed nor counted in `covered_fraction`.
+
 `covered_through_seconds` is the end of the longest **contiguous prefix** that is fully
 transcribed, which is the number an agent can act on without reasoning about gaps. It is
-not the same as "the last unit that finished": the recorded runner processes turns in
-duration-bucketed order and restores chronological order afterwards, so completion is not
-contiguous in time. `covered_intervals` and `missing_intervals` therefore carry the exact
-truth, and a resume that only honours the watermark is correct but may redo work the
-ledger shows was already done.
+not the same as "the last unit that finished": the runner processes turns in duration-bucketed
+order and restores chronological order afterwards. On an incomplete Qwen run, completed units
+after the first gap are deliberately omitted from the partial document and counted as missing;
+the emitted resume therefore produces a disjoint suffix. `covered_intervals` and
+`missing_intervals` still carry the exact artifact truth, and the schema can represent
+non-contiguous coverage for later partitioned backends without pretending it is a prefix.
 
 `--range <start>[:<end>]` is the resume mechanism, and it exists so the agent does **not**
 clip the audio. Clipping shifts the timeline, which means every bound in the second result
@@ -1153,9 +1205,34 @@ timestamps, performed by a consumer, which is exactly what the canonical-timelin
 exists to prevent. With `--range`, bounds in the second result are already on the original
 timeline and merging is concatenation.
 
+A ranged run also records the selection in the embedded executed plan:
+
+```json
+{
+  "range": {
+    "requested": [1402.88, 1794.2],
+    "selected_unit_scope": [1402.88, 1794.2]
+  }
+}
+```
+
+`requested` is the validated interval (an open end resolves to the canonical WAV duration),
+while `selected_unit_scope` can expand to whole processing-unit boundaries. On an incomplete
+Qwen run, only the longest chronological prefix is published; later duration-bucketed successes
+are rerun so the `--range` continuation is disjoint rather than asking export to guess duplicates.
+Auxiliary VAD, overlap, and abstention spans use the same expanded scope and are owned by their
+start. An open range reaches the canonical duration even when the last diarized turn ends earlier,
+so tail evidence belongs to the continuation instead of disappearing between partial documents.
+For an incomplete hand-written range that begins in a diarization gap, coverage remains bounded to
+the selected processing units while auxiliary ownership begins at the requested bound; the gap's
+evidence is preserved without claiming it was transcribed.
+
 The partial result is a **conforming result document** with `complete: false` and the same
 `coverage` block, so every floor still holds inside it: no synthesized bounds, abstentions
 survive, punctuation invariant intact for the units that ran. It is not a debug dump.
+If `units_completed` is zero, `fix` is deliberately a sentence rather than a `--range` command:
+the deterministic run has no later unit to skip to, so replaying the same request cannot be
+presented as a remedy.
 
 Ids are document-scoped, so merging two results means re-numbering. `export` accepts
 several transcripts in timeline order and re-ids as it goes, which covers the subtitle

--- a/TRANSCRIBE_DESIGN_HANDOFF.md
+++ b/TRANSCRIBE_DESIGN_HANDOFF.md
@@ -1,10 +1,12 @@
 # `transcribe` — design handoff
 
-**You are picking this up to produce a technical design and an implementation plan.** The
-agent-facing surface is settled and signed off; none of it is built. Your job is the layer
-underneath: modules, interfaces, adapter boundaries, provisioning mechanics, test strategy,
-and a sequenced plan. This document tells you what is decided, what is deliberately open,
-what will bite you, and what the evidence actually supports.
+**Historical design handoff; implementation is in progress.** The agent-facing surface is
+settled and signed off. Phases 0–B are on `main`; phase C implements the transport, orchestrator,
+and both Qwen stacks. Issues #22–#24 are the remaining FireRed, VibeVoice, and export phases.
+Use [HANDOFF.md](HANDOFF.md) for current repository state and
+[TRANSCRIBE_IMPLEMENTATION_PLAN.md](TRANSCRIBE_IMPLEMENTATION_PLAN.md) for phase boundaries.
+This document remains authoritative for the design decisions and evidence traps that produced
+that plan.
 
 Nothing here restates the three spec documents. Read them; they are authoritative.
 
@@ -92,9 +94,9 @@ you recognise a settled question when you meet one.
    the Swift product built and launched, and the `mlx-audio` private-API guard matching its pin.
    The suite still runs on a `FakeToolchain` and `FakeFetcher` in an isolated root, so treat a
    green suite as covering the rules and not the integration — the integration evidence is in
-   `fix/cli-provisioning-bugs`. `pull --want` is now **refused** rather than accepted and
-   ignored, until the planner lands
-   ([#12](https://github.com/fyang0507/audio-processing-cli/issues/12)); `--stack` still
+   `fix/cli-provisioning-bugs`. `pull --want` is **refused** rather than accepted and ignored;
+   the shipped planner names the exact packages and `pull` still accepts either those ids or a
+   deliberately over-provisioned stack. `--stack` still
    over-provisions, and now tolerates a package whose toolchain is missing instead of aborting
    the whole pull.
 4. **Partial results and resume.** Exit 4 writes a result with a coverage ledger. How work

--- a/TRANSCRIBE_HAPPY_PATH.md
+++ b/TRANSCRIBE_HAPPY_PATH.md
@@ -1,7 +1,8 @@
-# `transcribe` happy paths — mocked, per use case
+# `transcribe` happy paths — per use case
 
-**Status: mock.** Nothing here has been executed; no command below exists yet. This is
-the unabridged step-by-step an implementer can diff against and an agent can read as a
+**Status: Qwen execution shipped; FireRed, VibeVoice, and export remain specified.** The Qwen
+`run` and refusal blocks are exercised against real serializer output. This is the unabridged
+step-by-step an implementer can diff against and an agent can read as a
 worked example. [TRANSCRIBE_CONTRACT.md](TRANSCRIBE_CONTRACT.md) is organized around
 *why* the surface looks like this and abridges output to whatever differs; this document
 does the opposite — it shows every command in order and the complete stdout of each, with no
@@ -232,8 +233,8 @@ audio transcribe plan --input meeting.m4a \
     "diarizer":   {"backend": "fluidaudio", "version": "0.15.5",
                    "revision": "19600a485baa4998812e4654b70d2bab8f2c9949",
                    "environment": "swift",
-                   "config": {"preset": "quality", "step_ratio": 0.1,
-                              "min_segment_duration": 0.0, "output": "regular",
+                   "config": {"step_ratio": 0.1,
+                              "min_segment_duration": 0.0,
                               "threshold": 0.6, "batch_size": 32},
                    "config_note": "the shipped default supplies no speaker-count prior and enables overlapping_segments only when overlapped_speech is requested; the cited quality figures used both --num-speakers 2 and --overlapping-segments, so they do not measure this request",
                    "selected_by": "add_on_required_by:diarization"},
@@ -539,11 +540,16 @@ Exit 0. `meeting.timed.json`:
       "stage_wall_seconds": {"decode": 3.91, "diarizer": 14.68,
                              "asr": 54.02, "aligner": 46.77},
       "total_wall_seconds": 119.38,
-      "peak_rss_bytes_by_stage": {"diarizer": 588251136, "asr": 3243020288,
+      "peak_rss_bytes_by_stage": {"decode": 52363264,
+                                  "diarizer": 588251136, "asr": 3243020288,
                                   "aligner": 2104492032},
       "peak_rss_bytes": 3243020288,
+      "peak_mps_live_bytes_by_stage": {"asr": 3028287488,
+                                        "aligner": 1987051520},
+      "peak_mps_live_bytes": 3028287488,
       "segments": 2,
       "words": 13,
+      "segments_without_words": 0,
       "turns": 2,
       "abstentions": 2
     }
@@ -560,7 +566,28 @@ not against these trimmed prints.
 
 Note `peak_rss_bytes` is the **maximum** of the per-stage peaks, not their sum — that is
 what `execution.residency` buys, and the per-stage numbers are kept so the claim is
-checkable rather than asserted.
+checkable rather than asserted. A per-stage RSS value is the total footprint of the process
+executing that stage, runtime and orchestration included; it is not backend-owned allocation.
+For in-process VAD it is the core process high-water mark observed through the stage.
+`peak_mps_live_bytes_by_stage` is the MLX allocator's device-memory high-water mark, excludes
+ordinary RSS and non-MLX processes, and its aggregate is likewise a maximum rather than a sum.
+
+The run recomputes `source.duration_seconds` from the canonical decode's PCM frame count so
+coverage uses the timeline actually processed. The path remains the original media path, and
+no temporary WAV format, sample-rate, or channel field enters the public `source` object.
+
+A run invoked with `--range 1402.88:` adds this exact subtree to
+`provenance.plan.execution`; an open end resolves to the canonical WAV duration, and selected
+scope may expand to whole processing-unit bounds:
+
+```json
+{
+  "range": {
+    "requested": [1402.88, 1794.2],
+    "selected_unit_scope": [1402.88, 1794.2]
+  }
+}
+```
 
 ### 1.5 Export subtitles
 
@@ -777,7 +804,9 @@ catch.
 
 It carries **no `words` array**, which is correct and is not an abstention: the aligner is
 not run on a segment with no speech to align. So `words` is absent on some segments while
-`word_timestamps` is `produced`, and `observed.segments_without_words` records how many.
+`word_timestamps` is `produced`, and `observed.segments_without_words` records how many segments
+carry no `words` key. A present empty array is a successful alignment with zero lexical tokens,
+not an abstention.
 
 ### 2.3 Export subtitles with speaker voice tags
 
@@ -1195,12 +1224,38 @@ pin to select among. Pins choose between implementations of a role that exists.
 
 ### 4.9 The rest
 
+Existing output is an actionable collision, so the refusal preserves the full request and adds
+the explicit overwrite decision:
+
+```json
+{
+  "code": "output_exists",
+  "field": "--output",
+  "provided": "meeting.timed.json",
+  "existing": "meeting.timed.json",
+  "fix": "audio transcribe run --input meeting.m4a --stack qwen-1.7b --want diarization,word_timestamps --language Cantonese -o meeting.timed.json --force"
+}
+```
+
+No force flag may target the source, including through the derived partial filename. The tool
+does not invent a replacement path owned by the caller:
+
+```json
+{
+  "code": "output_is_canonical_input",
+  "field": "--output",
+  "provided": "meeting.json",
+  "resolved_target": "meeting.partial.json",
+  "fix": "choose an --output whose transcript and derived partial paths do not resolve to the canonical input; --force cannot override this"
+}
+```
+
 | Code | Exit | Trigger | What `fix` says |
 | --- | --- | --- | --- |
 | `packages_not_provisioned` | 3 | `run` before `pull` | The `audio packages pull --stack` line for this stack — every package it can use, since narrowing a pull to a want set is reserved for the planner |
 | `package_integrity_failed` | 3 | a digest, size, or revision mismatch on something already provisioned | `audio packages pull --repair <package>` |
 | `timing_required_for_format` | 2 | `export --format srt` on a transcript with no word timing | The `transcribe run` line that would produce timing, with `word_timestamps` added |
-| `run_incomplete` | 4 | budget exhausted, or a stage died part-way on a partitioned stack | The `--range <watermark>:` line that transcribes only what is missing |
+| `run_incomplete` | 4 | budget exhausted, or a stage died part-way on a partitioned stack | The `--range <watermark>:` line that transcribes only what is missing; a sentence instead when zero units completed and no range can make progress |
 | `backend_failed` | 1 | a crash, most often out of memory | A suggestion — a smaller stack, or freeing memory — and it is a suggestion, not a guarantee |
 
 The last row is the honest exception. Everything above it has a correction the tool can
@@ -1211,6 +1266,28 @@ toolchain.
 Two further refusals belong to `audio packages pull` rather than to `transcribe`, and §1.3
 publishes both: `want_not_implemented` and `stack_conflicts_with_named_packages`, each exit 2 and
 each a refusal of an argument that used to be accepted and ignored.
+
+A Qwen budget stop emits this exit-4 shape and writes the conforming partial named by `output`:
+
+```json
+{
+  "code": "run_incomplete",
+  "role": "asr",
+  "backend": "qwen3-asr-1.7b-8bit",
+  "detail": "global generation budget exhausted after 148 of 195 turns",
+  "coverage": {
+    "scope_intervals": [[0.0, 1794.2]],
+    "covered_through_seconds": 1402.88,
+    "covered_fraction": 0.782,
+    "covered_intervals": [[0.0, 1402.88]],
+    "missing_intervals": [[1402.88, 1794.2]],
+    "units_total": 195,
+    "units_completed": 148
+  },
+  "output": "meeting.timed.partial.json",
+  "fix": "audio transcribe run --input meeting.m4a --stack qwen-1.7b --want diarization,word_timestamps --language Cantonese --range 1402.88: -o meeting.timed.rest.json"
+}
+```
 
 ## 5. Teardown
 

--- a/TRANSCRIBE_IMPLEMENTATION_PLAN.md
+++ b/TRANSCRIBE_IMPLEMENTATION_PLAN.md
@@ -310,7 +310,7 @@ resolves to `English`; the 30 names equal the provisioned checkpoint's `support_
 the `mlx` environment exists, and the test skips when it does not. A plan carries no
 `outcomes`.
 
-### Phase C — transport, orchestration, and the Qwen stacks
+### Phase C — transport, orchestration, and the Qwen stacks (issue #21; implemented)
 
 `transport.py`, `orchestrator.py`, the `decode`, `silero`, `diarizer`, `qwen`, and `aligner`
 adapters, their stage scripts, and `audio transcribe run` for `qwen-1.7b` and `qwen-0.6b`. Five
@@ -330,7 +330,7 @@ turn bounds equal the first run's for the units they share. The scaffold strip i
 the **no-hint** configuration (finding 2). `peak_rss_bytes` is the maximum of the per-stage
 peaks, never their sum.
 
-### Phase D — FireRed
+### Phase D — FireRed (issue #22; next)
 
 One stage script for the whole stack, three or four models by request. Carries the word
 partition (finding 5), `lid_regions[]` by region grouping with the label-constancy assertion
@@ -342,7 +342,7 @@ when a word is dropped from the stream. `lid_regions[]` bounds equal `vad_region
 a region with two distinct labels fails. With LID off, no `lang` or `lang_confidence` key exists
 anywhere in the document. `words` never carries a confidence field.
 
-### Phase E — VibeVoice
+### Phase E — VibeVoice (issue #23)
 
 Both forms of "no speaker" — the literal `"N/A"` and the absent key — become an absent key.
 Non-speech event tags survive as segments with bounds and no words. The truncation salvage of
@@ -355,7 +355,7 @@ offset from a real artifact, yields every complete segment before the cut, exit 
 coverage watermark at the last complete segment's end — and yields nothing at all through
 `post_process_transcription`, which is the reason the salvage exists.
 
-### Phase F — `export`
+### Phase F — `export` (issue #24)
 
 `srt`, `vtt`, `md`, `txt`, `jsonl`; several `--input` documents merged in timeline order with
 re-numbered ids; `timing_required_for_format` when word timing is absent; cue policy hard-coded

--- a/src/audio_cli/cli.py
+++ b/src/audio_cli/cli.py
@@ -25,12 +25,13 @@ from .pipeline import (
     write_report,
 )
 from .profiles import PROFILES, STAGE_ORDER, get_profile
-from .vad import SileroOnnxVad, VadError
 from .transcribe import catalog as transcribe_catalog
+from .transcribe import orchestrator as transcribe_orchestrator
 from .transcribe import planner as transcribe_planner
 from .transcribe import refusals as transcribe_refusals
 from .transcribe import stacks as transcribe_stacks
 from .transcribe.plan import serialize_plan
+from .vad import SileroOnnxVad, VadError
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -160,6 +161,25 @@ def _parser() -> argparse.ArgumentParser:
     plan_parser.add_argument("--vad", help="Pin the VAD backend for a requested vad capability.")
     plan_parser.add_argument(
         "--diarizer", help="Pin the diarizer backend when the request adds that role."
+    )
+    run_parser = transcribe_commands.add_parser(
+        "run", help="Execute one resolved Qwen transcription request."
+    )
+    run_parser.add_argument("--stack")
+    run_parser.add_argument("--input", type=Path)
+    run_parser.add_argument("--want", help="Comma-separated capability names.")
+    run_parser.add_argument("--language")
+    run_parser.add_argument("--vad", help="Pin the VAD backend for a requested vad capability.")
+    run_parser.add_argument(
+        "--diarizer", help="Pin the diarizer backend when the request adds that role."
+    )
+    run_parser.add_argument(
+        "--range", dest="run_range", help="Process units intersecting START: or START:END."
+    )
+    run_parser.add_argument("--format", choices=("json", "md", "txt"), default="json")
+    run_parser.add_argument("-o", "--output", type=Path)
+    run_parser.add_argument(
+        "--force", action="store_true", help="Replace an existing output or partial result."
     )
     return parser
 
@@ -301,7 +321,7 @@ def _run_packages(args: argparse.Namespace) -> int:
 
 def _run_transcribe(args: argparse.Namespace) -> int:
     command = args.transcribe_command
-    wants = args.want if command == "plan" else None
+    wants = args.want if command in {"plan", "run"} else None
     request = transcribe_planner.resolve_request(
         stack_id=args.stack,
         input_path=args.input,
@@ -310,6 +330,32 @@ def _run_transcribe(args: argparse.Namespace) -> int:
         vad=getattr(args, "vad", None),
         diarizer=getattr(args, "diarizer", None),
     )
+    if command == "run":
+        if request.stack.id not in {"qwen-1.7b", "qwen-0.6b"}:
+            issue = 22 if request.stack.id == "firered" else 23
+            raise transcribe_refusals.stack_run_unavailable(request.stack.id, issue)
+        try:
+            run_range = transcribe_orchestrator.parse_range(args.run_range)
+        except ValueError as exc:
+            raise transcribe_refusals.range_invalid(
+                request.input_path,
+                request.stack.id,
+                request.wants,
+                str(args.run_range),
+                str(exc),
+                language=request.language,
+                vad=request.vad,
+                diarizer=request.diarizer,
+            ) from exc
+        transcribe_orchestrator.validate_output_targets(
+            request,
+            args.output,
+            output_format=args.format,
+            run_range=run_range,
+            force=args.force,
+        )
+    else:
+        run_range = None
     # Validation above is deliberately complete before this probe, and the registry is read
     # only after the probe.  No request refusal can be shadowed by provisioning state.
     metadata = transcribe_catalog.input_metadata(
@@ -329,6 +375,22 @@ def _run_transcribe(args: argparse.Namespace) -> int:
             request, metadata, provisioned_packages=ready
         )
         _print_json(serialize_plan(plan))
+        return 0
+    if command == "run":
+        product = transcribe_orchestrator.run(
+            request,
+            metadata,
+            output=args.output,
+            output_format=args.format,
+            run_range=run_range,
+            force=args.force,
+        )
+        if args.format == "json":
+            _print_json(product.payload)
+        else:
+            sys.stdout.write(
+                transcribe_orchestrator.render_human(product.payload, args.format)
+            )
         return 0
     raise ValueError(f"unknown transcribe command {command!r}")
 

--- a/src/audio_cli/transcribe/adapters/__init__.py
+++ b/src/audio_cli/transcribe/adapters/__init__.py
@@ -1,0 +1,22 @@
+"""Normalization boundaries for transcription backends."""
+
+from .aligner import normalize_aligned_words
+from .diarizer import DiarizationPlan, reconcile_turns
+from .qwen import (
+    normalize_qwen_segments,
+    sentence_segments,
+    split_sentences,
+    strip_qwen_scaffold,
+)
+from .silero import normalize_vad_regions
+
+__all__ = [
+    "DiarizationPlan",
+    "normalize_aligned_words",
+    "normalize_qwen_segments",
+    "normalize_vad_regions",
+    "reconcile_turns",
+    "sentence_segments",
+    "split_sentences",
+    "strip_qwen_scaffold",
+]

--- a/src/audio_cli/transcribe/adapters/aligner.py
+++ b/src/audio_cli/transcribe/adapters/aligner.py
@@ -1,0 +1,53 @@
+"""Normalize per-segment forced-alignment output."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+ROUNDING_TOLERANCE_SECONDS = 0.000501
+
+
+def normalize_aligned_words(
+    raw: Mapping[str, Any],
+    segments: Sequence[Mapping[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    values = raw.get("segments", [])
+    if not isinstance(values, list):
+        raise TypeError("aligner stage result segments must be an array")
+    by_id = {str(item["unit_id"]): item for item in segments}
+    normalized: dict[str, list[dict[str, Any]]] = {}
+    for item in values:
+        if not isinstance(item, Mapping):
+            raise TypeError("aligner stage segment must be an object")
+        identifier = str(item.get("unit_id", ""))
+        if identifier not in by_id or identifier in normalized:
+            raise ValueError(f"aligner returned unknown or duplicate unit {identifier!r}")
+        words = item.get("words")
+        if words is None:
+            continue
+        if not isinstance(words, list):
+            continue
+        candidate = []
+        try:
+            for word in words:
+                if not isinstance(word, Mapping) or not isinstance(word.get("text"), str):
+                    raise TypeError(f"aligner returned an invalid word for {identifier!r}")
+                start = float(word["start"])
+                end = float(word["end"])
+                unit_start = float(by_id[identifier].get("start", 0.0))
+                unit_end = float(by_id[identifier].get("end", float("inf")))
+                if not math.isfinite(start) or not math.isfinite(end):
+                    raise ValueError(f"aligner returned invalid bounds for {identifier!r}")
+                if start < unit_start and unit_start - start <= ROUNDING_TOLERANCE_SECONDS:
+                    start = unit_start
+                if end > unit_end and end - unit_end <= ROUNDING_TOLERANCE_SECONDS:
+                    end = unit_end
+                if start < unit_start or end < start or end > unit_end:
+                    raise ValueError(f"aligner returned invalid bounds for {identifier!r}")
+                candidate.append({"text": word["text"], "start": start, "end": end})
+        except (KeyError, TypeError, ValueError):
+            continue
+        normalized[identifier] = candidate
+    return normalized

--- a/src/audio_cli/transcribe/adapters/decode.py
+++ b/src/audio_cli/transcribe/adapters/decode.py
@@ -1,0 +1,34 @@
+"""Canonical decode command construction.
+
+The source is input-only.  Every backend sees the one temporary PCM WAV this command writes,
+so all bounds remain on one 16 kHz sample timeline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def command(source: Path, target: Path) -> list[str]:
+    return [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-y",
+        "-i",
+        str(source),
+        "-map",
+        "0:a:0",
+        "-vn",
+        "-sn",
+        "-dn",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-c:a",
+        "pcm_s16le",
+        str(target),
+    ]

--- a/src/audio_cli/transcribe/adapters/diarizer.py
+++ b/src/audio_cli/transcribe/adapters/diarizer.py
@@ -1,0 +1,183 @@
+"""Exact turn reconciliation from FluidAudio's anonymous intervals.
+
+The thresholds and partition algorithm are the measured configuration in
+model_tests/benchmark/run_turn_attributed_mlx_asr.py.  This module removes raw Core ML
+embeddings at the boundary and makes every source sample belong to exactly one category.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any
+
+SAMPLE_RATE = 16_000
+RAW_FRAGMENT_MIN_SAMPLES = round(0.250 * SAMPLE_RATE)
+MERGE_GAP_MAX_SAMPLES = round(0.300 * SAMPLE_RATE)
+TURN_MIN_SAMPLES = round(0.500 * SAMPLE_RATE)
+
+
+@dataclass(frozen=True)
+class _Span:
+    start: int
+    end: int
+    speakers: tuple[str, ...]
+    fragment: bool
+
+    @property
+    def kind(self) -> str:
+        if len(self.speakers) > 1:
+            return "overlap"
+        if len(self.speakers) == 1:
+            return "single"
+        if self.fragment:
+            return "raw_fragment"
+        return "gap"
+
+
+@dataclass
+class _Turn:
+    start: int
+    end: int
+    speaker: str
+
+
+@dataclass(frozen=True)
+class DiarizationPlan:
+    units: tuple[dict[str, Any], ...]
+    turns: tuple[dict[str, Any], ...]
+    overlaps: tuple[dict[str, Any], ...]
+    short_turns: tuple[dict[str, Any], ...]
+    raw_fragments: tuple[dict[str, Any], ...]
+
+
+def _seconds(samples: int) -> float:
+    return round(samples / SAMPLE_RATE, 6)
+
+
+def _raw_segments(payload: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+    values = payload.get("segments")
+    if values is None and isinstance(payload.get("output"), Mapping):
+        values = payload["output"].get("segments")
+    if not isinstance(values, list):
+        raise TypeError("FluidAudio result lacks a segments array")
+    return values
+
+
+def _normalize(item: Mapping[str, Any], total: int) -> dict[str, Any]:
+    # FluidAudio 0.15.5 emits camelCase.  The snake-case variant is accepted for runner
+    # artifacts and test doubles.  Nothing else, notably its 256-float embedding, crosses.
+    start_raw = item.get("startTimeSeconds", item.get("start_s"))
+    end_raw = item.get("endTimeSeconds", item.get("end_s"))
+    speaker_raw = item.get("speakerId", item.get("speaker"))
+    start_s, end_s = float(start_raw), float(end_raw)
+    if not math.isfinite(start_s) or not math.isfinite(end_s) or speaker_raw is None \
+            or not str(speaker_raw):
+        raise ValueError("FluidAudio returned invalid fields")
+    start = max(0, min(total, round(start_s * SAMPLE_RATE)))
+    end = max(0, min(total, round(end_s * SAMPLE_RATE)))
+    if end <= start:
+        raise ValueError("FluidAudio returned an empty interval after source crop")
+    return {"start": start, "end": end, "speaker": str(speaker_raw)}
+
+
+def _spans(kept: list[dict[str, Any]], filtered: list[dict[str, Any]], total: int) -> list[_Span]:
+    speaker_events: dict[int, list[tuple[str, int]]] = defaultdict(list)
+    fragment_events: dict[int, list[int]] = defaultdict(list)
+    for item in kept:
+        speaker_events[item["start"]].append((item["speaker"], 1))
+        speaker_events[item["end"]].append((item["speaker"], -1))
+    for item in filtered:
+        fragment_events[item["start"]].append(1)
+        fragment_events[item["end"]].append(-1)
+    boundaries = sorted({0, total, *speaker_events, *fragment_events})
+    active: Counter[str] = Counter()
+    fragment_active = 0
+    result: list[_Span] = []
+    for left, right in pairwise(boundaries):
+        for speaker, delta in speaker_events.get(left, []):
+            active[speaker] += delta
+        for delta in fragment_events.get(left, []):
+            fragment_active += delta
+        if right <= left:
+            continue
+        speakers = tuple(sorted(
+            speaker for speaker, count in active.items() if count > 0
+        ))
+        span = _Span(
+            left,
+            right,
+            speakers,
+            fragment_active > 0 and not speakers,
+        )
+        if result and result[-1].end == span.start \
+                and result[-1].speakers == span.speakers \
+                and result[-1].fragment == span.fragment:
+            previous = result[-1]
+            result[-1] = _Span(previous.start, span.end, span.speakers, span.fragment)
+        else:
+            result.append(span)
+    return result
+
+
+def _turns(spans: list[_Span]) -> list[_Turn]:
+    result: list[_Turn] = []
+    index = 0
+    while index < len(spans):
+        span = spans[index]
+        if span.kind != "single":
+            index += 1
+            continue
+        turn = _Turn(span.start, span.end, span.speakers[0])
+        cursor = index
+        while cursor + 2 < len(spans):
+            gap, following = spans[cursor + 1], spans[cursor + 2]
+            if not (
+                gap.kind == "gap"
+                and gap.end - gap.start <= MERGE_GAP_MAX_SAMPLES
+                and following.kind == "single"
+                and following.speakers == (turn.speaker,)
+            ):
+                break
+            turn.end = following.end
+            cursor += 2
+        result.append(turn)
+        index = cursor + 1
+    return result
+
+
+def reconcile_turns(payload: Mapping[str, Any], *, duration_seconds: float) -> DiarizationPlan:
+    total = max(0, round(duration_seconds * SAMPLE_RATE))
+    normalized = [_normalize(item, total) for item in _raw_segments(payload)]
+    kept = [item for item in normalized if item["end"] - item["start"] >= RAW_FRAGMENT_MIN_SAMPLES]
+    filtered = [item for item in normalized if item["end"] - item["start"] < RAW_FRAGMENT_MIN_SAMPLES]
+    spans = _spans(kept, filtered, total)
+    turns = _turns(spans)
+    accepted = [item for item in turns if item.end - item.start >= TURN_MIN_SAMPLES]
+    short = [item for item in turns if item.end - item.start < TURN_MIN_SAMPLES]
+
+    units = tuple({
+        "unit_id": f"turn_{index}",
+        "speaker": turn.speaker,
+        "start": _seconds(turn.start),
+        "end": _seconds(turn.end),
+    } for index, turn in enumerate(accepted))
+    public_turns = tuple({
+        "turn_id": item["unit_id"], "speaker": item["speaker"],
+        "start": item["start"], "end": item["end"],
+    } for item in units)
+    overlaps = tuple({"start": _seconds(span.start), "end": _seconds(span.end)}
+                     for span in spans if span.kind == "overlap")
+    raw = tuple({"start": _seconds(span.start), "end": _seconds(span.end)}
+                for span in spans if span.kind == "raw_fragment")
+    shorts = tuple({"start": _seconds(turn.start), "end": _seconds(turn.end)}
+                   for turn in short)
+
+    # The runner's partition invariant: accepted windows cannot overlap. The other span kinds
+    # arise from the same atomic timeline, so a violation here indicates adapter drift.
+    if any(left["end"] > right["start"] for left, right in pairwise(units)):
+        raise ValueError("reconciled turn windows overlap")
+    return DiarizationPlan(units, public_turns, overlaps, shorts, raw)

--- a/src/audio_cli/transcribe/adapters/qwen.py
+++ b/src/audio_cli/transcribe/adapters/qwen.py
@@ -1,0 +1,171 @@
+"""Normalize the raw result of the pinned Qwen private batched API."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+# Observed by model_tests/benchmark/run_qwen_verbatim_probe.py and returned by the private
+# _generate_chunks_batched path used in run_turn_attributed_mlx_asr.py.  The public path strips
+# this wrapper; keeping it would put backend protocol text into the transcript.
+_SCAFFOLD = re.compile(r"^language ([^<]+)<asr_text>")
+_SENTENCE_END = frozenset(".!?。！？")
+_CLOSERS = frozenset("\"'”’」』】）)]")
+
+
+def strip_qwen_scaffold(text: str) -> str:
+    return _SCAFFOLD.sub("", text, count=1)
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split punctuated model text without inventing or removing punctuation."""
+    result: list[str] = []
+    pending = ""
+    start = 0
+    index = 0
+    while index < len(text):
+        character = text[index]
+        boundary = character in _SENTENCE_END or character == "\n"
+        if character == "." and index > 0 and index + 1 < len(text) \
+                and text[index - 1].isdigit() and text[index + 1].isdigit():
+            boundary = False
+        if not boundary:
+            index += 1
+            continue
+        end = index + 1
+        while end < len(text) and text[end] in _SENTENCE_END:
+            end += 1
+        while end < len(text) and text[end] in _CLOSERS:
+            end += 1
+        sentence = text[start:end].strip()
+        if _plain(sentence):
+            result.append(pending + sentence)
+            pending = ""
+        elif sentence:
+            if result:
+                result[-1] += sentence
+            else:
+                pending += sentence
+        start = end
+        while start < len(text) and text[start].isspace():
+            start += 1
+        index = start
+    remainder = text[start:].strip()
+    if remainder:
+        result.append(pending + remainder)
+    elif pending and result:
+        result[-1] += pending
+    elif pending:
+        result.append(pending)
+    return result
+
+
+def _plain(text: str) -> str:
+    return "".join(
+        character.casefold() for character in text
+        if not character.isspace() and not unicodedata.category(character).startswith("P")
+    )
+
+
+def sentence_segments(
+    completed: Sequence[Mapping[str, Any]],
+    aligned: Mapping[str, Sequence[Mapping[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
+    """Turn processing-unit text into the sentence artifacts required by the floor.
+
+    When alignment ran, its word stream is partitioned by the punctuation invariant instead
+    of treating processing-unit bounds as sentence timing.
+    """
+    result: list[dict[str, Any]] = []
+    aligned = aligned or {}
+    for unit in completed:
+        identifier = str(unit["unit_id"])
+        sentences = split_sentences(str(unit["text"]))
+        words = list(aligned.get(identifier, ()))
+        unit_segments = []
+        try:
+            word_cursor = 0
+            for text in sentences:
+                segment = {"unit_id": identifier, "text": text}
+                if "speaker" in unit:
+                    segment["speaker"] = unit["speaker"]
+                if identifier in aligned:
+                    target = _plain(text)
+                    collected = []
+                    joined = ""
+                    while word_cursor < len(words) and len(joined) < len(target):
+                        word = dict(words[word_cursor])
+                        candidate = joined + _plain(str(word["text"]))
+                        if not target.startswith(candidate):
+                            raise ValueError(
+                                f"aligned words do not reproduce sentence text for {identifier!r}"
+                            )
+                        collected.append(word)
+                        joined = candidate
+                        word_cursor += 1
+                    if joined != target:
+                        raise ValueError(
+                            f"aligned words do not reproduce sentence text for {identifier!r}"
+                        )
+                    segment["words"] = collected
+                unit_segments.append(segment)
+            if identifier in aligned and word_cursor != len(words):
+                raise ValueError(f"aligned words remain after sentence split for {identifier!r}")
+        except ValueError:
+            unit_segments = []
+            for text in sentences:
+                segment = {"unit_id": identifier, "text": text}
+                if "speaker" in unit:
+                    segment["speaker"] = unit["speaker"]
+                unit_segments.append(segment)
+        result.extend(unit_segments)
+    return result
+
+
+def normalize_qwen_segments(
+    raw: Mapping[str, Any],
+    units: Sequence[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return chronological completed segments and unfinished units.
+
+    Unit bounds and speakers are deterministic orchestration inputs. Qwen supplies text only;
+    its language scaffold is transport metadata and is intentionally not promoted to a result.
+    """
+    by_id = {str(item["unit_id"]): item for item in units}
+    completed: list[dict[str, Any]] = []
+    unfinished: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    values = raw.get("units", [])
+    if not isinstance(values, list):
+        raise TypeError("Qwen stage result units must be an array")
+    for item in values:
+        if not isinstance(item, Mapping):
+            raise TypeError("Qwen stage result unit must be an object")
+        identifier = str(item.get("unit_id", ""))
+        if identifier not in by_id or identifier in seen:
+            raise ValueError(f"Qwen stage returned unknown or duplicate unit {identifier!r}")
+        seen.add(identifier)
+        unit = by_id[identifier]
+        if item.get("processed") is not True:
+            unfinished.append(dict(unit))
+            continue
+        text = item.get("text")
+        if not isinstance(text, str):
+            raise TypeError(f"Qwen stage unit {identifier!r} has no string text")
+        segment = {
+            "unit_id": identifier,
+            "start": float(unit["start"]),
+            "end": float(unit["end"]),
+            "text": strip_qwen_scaffold(text),
+        }
+        if "speaker" in unit:
+            segment["speaker"] = str(unit["speaker"])
+        completed.append(segment)
+    for unit in units:
+        if str(unit["unit_id"]) not in seen:
+            unfinished.append(dict(unit))
+    completed.sort(key=lambda item: (item["start"], item["end"], item["unit_id"]))
+    unfinished.sort(key=lambda item: (float(item["start"]), float(item["end"])))
+    return completed, unfinished

--- a/src/audio_cli/transcribe/adapters/silero.py
+++ b/src/audio_cli/transcribe/adapters/silero.py
@@ -1,0 +1,17 @@
+"""Publish only the VAD fields the normalized schema owns."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def normalize_vad_regions(regions: Iterable[Mapping[str, Any] | object]) -> list[dict[str, float]]:
+    result = []
+    for region in regions:
+        if isinstance(region, Mapping):
+            start, end = region["start"], region["end"]
+        else:
+            start, end = region.start, region.end
+        result.append({"start": round(float(start), 6), "end": round(float(end), 6)})
+    return result

--- a/src/audio_cli/transcribe/orchestrator.py
+++ b/src/audio_cli/transcribe/orchestrator.py
@@ -1,0 +1,773 @@
+"""Qwen transcription orchestration over one canonical source timeline."""
+
+from __future__ import annotations
+
+import math
+import os
+import resource
+import shlex
+import sys
+import time
+import wave
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from audio_cli import paths
+from audio_cli.environments import backends
+from audio_cli.environments import environments as environment_catalog
+from audio_cli.environments import packages as package_catalog
+from audio_cli.media import atomic_write_json, temporary_directory
+from audio_cli.packages import load_registry
+from audio_cli.vad import SileroOnnxVad, VadError
+
+from . import refusals
+from .adapters import (
+    normalize_aligned_words,
+    normalize_qwen_segments,
+    normalize_vad_regions,
+    reconcile_turns,
+    sentence_segments,
+)
+from .catalog import InputMetadata
+from .plan import Plan, serialize_plan
+from .planner import ResolvedRequest, build_plan
+from .result import ABSENT, NormalizedResult, ResultError, serialize_result
+from .transport import StageFailure, StageOutcome, StageTransport
+
+
+@dataclass(frozen=True)
+class RunRange:
+    start: float
+    end: float | None
+    provided: str
+
+
+@dataclass(frozen=True)
+class RunProduct:
+    payload: dict[str, Any]
+
+
+def _self_peak_rss() -> int:
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def parse_range(value: str | None) -> RunRange | None:
+    if value is None:
+        return None
+    left, separator, right = value.partition(":")
+    if not separator:
+        raise ValueError("--range must be START: or START:END")
+    try:
+        start = float(left)
+        end = float(right) if right else None
+    except ValueError as exc:
+        raise ValueError("--range bounds must be finite seconds") from exc
+    if not math.isfinite(start) or start < 0 or (
+        end is not None and (not math.isfinite(end) or end <= start)
+    ):
+        raise ValueError("--range must satisfy 0 <= START < END")
+    return RunRange(start, end, value)
+
+
+def _validate_range(
+    request: ResolvedRequest, run_range: RunRange | None, duration: float
+) -> RunRange | None:
+    if run_range is None:
+        return None
+    end = min(run_range.end if run_range.end is not None else duration, duration)
+    if run_range.start >= duration or end <= run_range.start:
+        raise refusals.range_invalid(
+            request.input_path,
+            request.stack.id,
+            request.wants,
+            run_range.provided,
+            "range does not intersect the source duration",
+            language=request.language,
+            vad=request.vad,
+            diarizer=request.diarizer,
+        )
+    return RunRange(run_range.start, end, run_range.provided)
+
+
+def _core_plan(plan: Plan) -> dict[str, Any]:
+    payload = serialize_plan(plan)
+    payload.pop("sample_output")
+    return payload
+
+
+def _missing_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    item = {
+        "package": record["package"],
+        "kind": record["kind"],
+        "bytes": record["bytes"],
+    }
+    if "requires_tool" in record:
+        item["requires_tool"] = list(record["requires_tool"])
+    return item
+
+
+def _paths_exist(materialized: Mapping[str, Any]) -> bool:
+    found = []
+    if materialized.get("path"):
+        found.append(Path(str(materialized["path"])))
+    values = materialized.get("paths")
+    if isinstance(values, Mapping):
+        found.extend(Path(str(value)) for value in values.values())
+    return bool(found) and all(path.exists() for path in found)
+
+
+def preflight(plan: Plan, registry: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    """Fail before decode or model load if the selected materialization is not usable."""
+    entries = registry.get("packages", {})
+    if not isinstance(entries, Mapping):
+        entries = {}
+    missing = []
+    for record in plan.packages:
+        if record.get("auto_fetch"):
+            continue
+        entry = entries.get(record["package"])
+        if not isinstance(entry, Mapping) or entry.get("state") != "ready":
+            missing.append(_missing_record(record))
+    if missing:
+        known = sum(int(item["bytes"] or 0) for item in missing)
+        unsized = [str(item["package"]) for item in missing if item["bytes"] is None]
+        raise refusals.packages_not_provisioned(plan.stack, missing, known, unsized)
+
+    failures = []
+    catalog = package_catalog()
+    environment_entries = registry.get("environments", {})
+    if not isinstance(environment_entries, Mapping):
+        environment_entries = {}
+    runtime_packages: dict[str, str] = {}
+    for record in plan.packages:
+        if record.get("auto_fetch"):
+            continue
+        package = catalog[str(record["package"])]
+        if package.environment != "core":
+            runtime_packages.setdefault(package.environment, package.id)
+    for environment, package_id in runtime_packages.items():
+        entry = environment_entries.get(environment, {})
+        actual_state = entry.get("state") if isinstance(entry, Mapping) else None
+        if actual_state != "ready":
+            failures.append({
+                "package": package_id,
+                "check": f"environment_{environment}_ready",
+                "expected": "ready",
+                "actual": actual_state or "absent",
+            })
+            continue
+        if environment_catalog()[environment].has_interpreter:
+            interpreter = paths.env_python(environment)
+            if not interpreter.is_file() or not os.access(interpreter, os.X_OK):
+                failures.append({
+                    "package": package_id,
+                    "check": f"environment_{environment}_python_executable",
+                    "expected": True,
+                    "actual": False,
+                })
+    selected: dict[str, Mapping[str, Any]] = {}
+    for record in plan.packages:
+        identifier = str(record["package"])
+        if record.get("auto_fetch"):
+            continue
+        entry = entries[identifier]
+        assert isinstance(entry, Mapping)
+        selected[identifier] = entry
+        materialized = entry.get("materialized", {})
+        if not isinstance(materialized, Mapping) or not _paths_exist(materialized):
+            failures.append({
+                "package": identifier,
+                "check": "materialized_paths_exist",
+                "expected": True,
+                "actual": False,
+            })
+            continue
+        source = catalog[identifier].source
+        if source.get("type") in {"huggingface", "git+build"}:
+            expected = source.get("revision", source.get("commit"))
+            actual = materialized.get("revision")
+            if actual != expected:
+                failures.append({
+                    "package": identifier, "check": "pinned_revision",
+                    "expected": expected, "actual": actual,
+                })
+        elif source.get("type") == "huggingface_multi":
+            expected = [item["revision"] for item in source["repos"]]
+            actual = materialized.get("revisions")
+            if actual != expected:
+                failures.append({
+                    "package": identifier, "check": "pinned_revisions",
+                    "expected": expected, "actual": actual,
+                })
+        if identifier == "fluidaudio":
+            product = str(source["product"])
+            if materialized.get("built") is not True:
+                failures.append({
+                    "package": identifier, "check": "built",
+                    "expected": True, "actual": materialized.get("built"),
+                })
+            elif materialized.get("product_runs") is not True:
+                raise refusals.package_build_unusable(identifier, product)
+            else:
+                checkout = Path(str(materialized["path"]))
+                candidates = {
+                    path.resolve()
+                    for path in checkout.glob(f".build/**/release/{product}")
+                    if path.is_file() and os.access(path, os.X_OK)
+                }
+                if len(candidates) != 1:
+                    failures.append({
+                        "package": identifier,
+                        "check": "built_product_executable",
+                        "expected": 1,
+                        "actual": len(candidates),
+                    })
+    if failures:
+        raise refusals.package_integrity_failed(failures)
+    return selected
+
+
+def _fixed_units(duration: float, request: ResolvedRequest) -> list[dict[str, Any]]:
+    rule = request.stack.processing["unit_count_rule"]
+    if rule["kind"] != "fixed_seconds":
+        raise ValueError(f"{request.stack.id} does not declare fixed-second processing units")
+    seconds = float(rule["seconds"])
+    return [{
+        "unit_id": f"unit_{index}",
+        "start": round(index * seconds, 6),
+        "end": round(min(duration, (index + 1) * seconds), 6),
+    } for index in range(math.ceil(duration / seconds))]
+
+
+def _select_range(
+    units: Sequence[dict[str, Any]], run_range: RunRange | None, duration: float
+) -> tuple[list[dict[str, Any]], float, float]:
+    start = run_range.start if run_range else 0.0
+    end = min(run_range.end if run_range and run_range.end is not None else duration, duration)
+    return [dict(item) for item in units if item["end"] > start and item["start"] < end], start, end
+
+
+def _materialized_path(entries: Mapping[str, Mapping[str, Any]], identifier: str) -> Path:
+    value = entries[identifier].get("materialized", {}).get("path")
+    if not value:
+        raise refusals.package_integrity_failed(({
+            "package": identifier, "check": "materialized_path",
+            "expected": "present", "actual": value,
+        },))
+    return Path(str(value))
+
+
+def _read_pcm16(path: Path) -> tuple[np.ndarray, int]:
+    with wave.open(str(path), "rb") as handle:
+        rate = handle.getframerate()
+        channels = handle.getnchannels()
+        width = handle.getsampwidth()
+        samples = np.frombuffer(handle.readframes(handle.getnframes()), dtype="<i2")
+    if rate != 16_000 or channels != 1 or width != 2:
+        raise ValueError("canonical decode is not mono 16 kHz PCM16")
+    return samples.astype(np.float32) / 32768.0, rate
+
+
+def _detect_vad(
+    path: Path, detector: Any | None, config: Mapping[str, Any]
+) -> tuple[list[dict[str, Any]], float, int]:
+    """Run core VAD in a short frame so its PCM and session die before model stages."""
+    started = time.perf_counter()
+    samples, rate = _read_pcm16(path)
+    selected = detector or SileroOnnxVad()
+    regions = selected.detect(samples, rate, **config)
+    normalized = normalize_vad_regions(regions)
+    return normalized, round(time.perf_counter() - started, 6), _self_peak_rss()
+
+
+def _record_metrics(outcomes: Sequence[StageOutcome], result: NormalizedResult) -> dict[str, Any]:
+    walls = {item.role: item.wall_seconds for item in outcomes}
+    observed: dict[str, Any] = {
+        "stage_wall_seconds": walls,
+        "total_wall_seconds": round(sum(walls.values()), 6),
+        "segments": len(result.segments),
+        "words": sum(len(item.get("words", [])) for item in result.segments),
+        "abstentions": len(result.abstentions),
+    }
+    if result.turns is not ABSENT:
+        observed["turns"] = len(result.turns)
+    if result.vad_regions is not ABSENT:
+        observed["vad_regions"] = len(result.vad_regions)
+    if result.overlapped_speech is not ABSENT:
+        observed["overlapped_speech"] = len(result.overlapped_speech)
+    if "word_timestamps" in result.requested_capabilities:
+        observed["segments_without_words"] = sum(
+            1 for item in result.segments if "words" not in item
+        )
+    rss = {item.role: item.peak_rss_bytes for item in outcomes if item.peak_rss_bytes is not None}
+    if rss:
+        observed["peak_rss_bytes_by_stage"] = rss
+        observed["peak_rss_bytes"] = max(rss.values())
+    mps = {
+        item.role: item.peak_mps_live_bytes
+        for item in outcomes if item.peak_mps_live_bytes is not None
+    }
+    if mps:
+        observed["peak_mps_live_bytes_by_stage"] = mps
+        observed["peak_mps_live_bytes"] = max(mps.values())
+    return observed
+
+
+def _coverage(
+    unfinished: Sequence[Mapping[str, Any]], *, total_units: int,
+    completed_units: int, scope_start: float, scope_end: float,
+) -> dict[str, Any]:
+    watermark = min(float(item["start"]) for item in unfinished)
+    missing = [[round(watermark, 6), round(scope_end, 6)]]
+    covered = [] if watermark <= scope_start else [[
+        round(scope_start, 6), round(watermark, 6)
+    ]]
+    covered_seconds = sum(end - start for start, end in covered)
+    return {
+        "scope_intervals": [[round(scope_start, 6), round(scope_end, 6)]],
+        "covered_through_seconds": round(watermark, 6),
+        "covered_fraction": round(covered_seconds / (scope_end - scope_start), 6),
+        "covered_intervals": covered,
+        "missing_intervals": missing,
+        "units_total": total_units,
+        "units_completed": completed_units,
+    }
+
+
+def _span_owned(
+    span: Mapping[str, Any], *, scope: tuple[float, float] | None,
+) -> bool:
+    """Assign each whole-file auxiliary observation to exactly one ranged document."""
+    start = float(span["start"])
+    return scope is None or scope[0] <= start < scope[1]
+
+
+def _partial_path(source: Path, output: Path | None) -> Path:
+    if output is None:
+        return source.with_name(f"{source.stem}.partial.json")
+    return output.with_name(f"{output.with_suffix('').name}.partial.json")
+
+
+def _unused_partial_path(source: Path) -> Path:
+    candidate = _partial_path(source, None)
+    index = 2
+    while candidate.exists():
+        candidate = source.with_name(f"{source.stem}.partial.{index}.json")
+        index += 1
+    return candidate
+
+
+def validate_output_targets(
+    request: ResolvedRequest,
+    output: Path | None,
+    *,
+    output_format: str,
+    run_range: RunRange | None,
+    force: bool,
+) -> None:
+    """Refuse every destination collision before decoding or model work begins."""
+    source = request.input_path
+    if output is not None and source.resolve() == output.resolve():
+        raise refusals.output_is_canonical_input(output, output)
+    if output is not None and source.resolve() == _partial_path(source, output).resolve():
+        raise refusals.output_is_canonical_input(output, _partial_path(source, output))
+    targets = (("Output", output),)
+    if output is not None:
+        targets += (("Partial output", _partial_path(source, output)),)
+    for _, target in targets:
+        if target is not None and target.exists() and not force:
+            raise refusals.output_exists(
+                source,
+                request.stack.id,
+                request.wants,
+                output,
+                target,
+                language=request.language,
+                vad=request.vad,
+                diarizer=request.diarizer,
+                run_range=run_range.provided if run_range is not None else None,
+                output_format=output_format,
+            )
+
+
+def _resume_command(
+    request: ResolvedRequest,
+    coverage: Mapping[str, Any],
+    output: Path,
+    run_range: RunRange | None,
+) -> str:
+    if int(coverage["units_completed"]) == 0:
+        return (
+            "no processing unit completed; --range would repeat the same deterministic "
+            "work, so inspect the first unit or backend budget before retrying"
+        )
+    stem = output.stem
+    if stem.endswith(".partial"):
+        stem = stem.removesuffix(".partial")
+    rest = output.with_name(f"{stem}.rest.json")
+    parts = [
+        "audio", "transcribe", "run", "--input", str(request.input_path),
+        "--stack", request.stack.id,
+    ]
+    if request.wants:
+        parts.extend(("--want", ",".join(request.wants)))
+    if request.language:
+        parts.extend(("--language", request.language))
+    if request.vad:
+        parts.extend(("--vad", request.vad))
+    if request.diarizer:
+        parts.extend(("--diarizer", request.diarizer))
+    watermark = coverage["covered_through_seconds"]
+    explicit_end = bool(
+        run_range is not None and run_range.provided.partition(":")[2]
+    )
+    range_value = (
+        f"{watermark}:{run_range.end}"
+        if explicit_end and run_range is not None
+        else f"{watermark}:"
+    )
+    parts.extend(("--range", range_value, "-o", str(rest)))
+    return shlex.join(parts)
+
+
+def render_human(payload: Mapping[str, Any], output_format: str) -> str:
+    lines = []
+    for item in payload["segments"]:
+        prefix = f"[{item['speaker']}] " if "speaker" in item else ""
+        lines.append(prefix + item["text"])
+    body = "\n".join(lines)
+    if output_format == "md":
+        return "# Transcript\n\n" + (body + "\n" if body else "")
+    return body + ("\n" if body else "")
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(text, encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _backend_fix(role: str, backend: str) -> str:
+    return (
+        f"inspect the {role} failure from {backend} and correct the reported runtime "
+        "condition before retrying"
+    )
+
+
+def _outcomes(
+    wants: Sequence[str], *, segments: Sequence[Mapping[str, Any]],
+) -> dict[str, str]:
+    outcomes = {name: "produced" for name in wants}
+    if "word_timestamps" in outcomes and any(
+        item.get("text") and "words" not in item for item in segments
+    ):
+        outcomes["word_timestamps"] = "abstained"
+    return outcomes
+
+
+def run(
+    request: ResolvedRequest,
+    metadata: InputMetadata,
+    *,
+    output: Path | None = None,
+    output_format: str = "json",
+    run_range: RunRange | None = None,
+    registry: Mapping[str, Any] | None = None,
+    transport: StageTransport | None = None,
+    vad_detector: Any | None = None,
+    force: bool = False,
+) -> RunProduct:
+    """Execute the two Qwen stacks and return their normalized result."""
+    if request.stack.id not in {"qwen-1.7b", "qwen-0.6b"}:
+        issue = 22 if request.stack.id == "firered" else 23
+        raise refusals.stack_run_unavailable(request.stack.id, issue)
+    validate_output_targets(
+        request,
+        output,
+        output_format=output_format,
+        run_range=run_range,
+        force=force,
+    )
+    document = registry if registry is not None else load_registry()
+    ready = {
+        identifier for identifier, entry in document.get("packages", {}).items()
+        if isinstance(entry, Mapping) and entry.get("state") == "ready"
+    }
+    plan = build_plan(request, metadata, provisioned_packages=ready)
+    entries = preflight(plan, document)
+    stage_transport = transport or StageTransport()
+    outcomes: list[StageOutcome] = []
+
+    with temporary_directory(prefix="audio-transcribe-") as directory:
+        canonical = directory / "canonical.wav"
+        active_role = "decode"
+        active_backend = "ffmpeg"
+        try:
+            outcomes.append(stage_transport.decode(request.input_path, canonical))
+            with wave.open(str(canonical), "rb") as handle:
+                if handle.getframerate() != 16_000 or handle.getnchannels() != 1 \
+                        or handle.getsampwidth() != 2:
+                    raise ValueError("canonical decode is not mono 16 kHz PCM16")
+                canonical_duration = round(
+                    handle.getnframes() / float(handle.getframerate()), 6
+                )
+            run_range = _validate_range(request, run_range, canonical_duration)
+            diarization = None
+            if "diarizer" in plan.roles:
+                active_role, active_backend = "diarizer", "fluidaudio"
+                fluid_entry = entries["fluidaudio"]
+                source = package_catalog()["fluidaudio"].source
+                outcome = stage_transport.diarize(
+                    checkout=Path(str(fluid_entry["materialized"]["path"])),
+                    product=str(source["product"]),
+                    audio=canonical,
+                    config=plan.roles["diarizer"]["config"],
+                    overlap="overlapped_speech" in request.wants,
+                    directory=directory,
+                )
+                outcomes.append(outcome)
+                diarization = reconcile_turns(
+                    outcome.payload, duration_seconds=canonical_duration
+                )
+                all_units = list(diarization.units)
+            else:
+                all_units = _fixed_units(canonical_duration, request)
+            selected_units, requested_start, requested_end = _select_range(
+                all_units, run_range, canonical_duration
+            )
+            if run_range is None:
+                scope_start, scope_end = 0.0, canonical_duration
+            elif selected_units:
+                scope_start = min(float(item["start"]) for item in selected_units)
+                scope_end = max(float(item["end"]) for item in selected_units)
+            else:
+                scope_start, scope_end = requested_start, requested_end
+
+            vad_regions: Any = ABSENT
+            if "vad" in plan.roles:
+                active_role, active_backend = "vad", "silero-vad"
+                config = plan.roles["vad"]["config"]
+                vad_regions, vad_wall, vad_peak = _detect_vad(
+                    canonical, vad_detector, config
+                )
+                outcomes.append(StageOutcome(
+                    "vad", "silero-vad", {}, vad_wall,
+                    peak_rss_bytes=vad_peak,
+                ))
+
+            asr_backend = str(plan.roles["asr"]["backend"])
+            active_role, active_backend = "asr", asr_backend
+            package_id = backends()[asr_backend].package
+            asr = stage_transport.qwen(
+                backend=asr_backend,
+                model=_materialized_path(entries, package_id),
+                audio=canonical,
+                units=selected_units,
+                language=request.language,
+                max_tokens=int(plan.roles["asr"]["config"]["max_tokens"]),
+                batch_size=int(plan.roles["asr"]["config"]["batch_size"]),
+                clear_cache_after_every_batch=bool(
+                    plan.roles["asr"]["config"]["clear_mlx_cache_after_every_batch"]
+                ),
+                directory=directory,
+            )
+            outcomes.append(asr)
+            completed, unfinished = normalize_qwen_segments(asr.payload, selected_units)
+            if unfinished:
+                # The backend runs duration-bucketed, so its completed set can have holes in
+                # source time. Publish only the chronological prefix; the resume command can
+                # then produce a disjoint continuation without asking #24 to guess duplicates.
+                watermark = min(float(item["start"]) for item in unfinished)
+                completed = [
+                    item for item in completed if float(item["end"]) <= watermark
+                ]
+                unfinished = [
+                    dict(item) for item in selected_units
+                    if float(item["start"]) >= watermark
+                ]
+
+            aligned: dict[str, list[dict[str, Any]]] = {}
+            if "aligner" in plan.roles and completed:
+                active_role, active_backend = "aligner", "qwen3-forcedaligner"
+                try:
+                    align = stage_transport.align(
+                        model=_materialized_path(entries, "qwen3-forcedaligner"),
+                        audio=canonical,
+                        segments=completed,
+                        directory=directory,
+                    )
+                    outcomes.append(align)
+                    aligned = normalize_aligned_words(align.payload, completed)
+                except StageFailure as exc:
+                    if exc.role != "aligner":
+                        raise
+                    aligned = {}
+                except (TypeError, ValueError):
+                    aligned = {}
+        except StageFailure as exc:
+            raise refusals.backend_failed(
+                exc.role, exc.backend, exc.detail,
+                _backend_fix(exc.role, exc.backend),
+            ) from exc
+        except (TypeError, ValueError, VadError) as exc:
+            raise refusals.backend_failed(
+                active_role, active_backend, str(exc),
+                _backend_fix(active_role, active_backend),
+            ) from exc
+
+        completed_ids = {item["unit_id"] for item in completed}
+        sentences = sentence_segments(
+            completed, aligned if "aligner" in plan.roles else None
+        )
+
+        segments = []
+        word_index = 0
+        for index, item in enumerate(sentences):
+            segment = {"segment_id": f"seg_{index}", "text": item["text"]}
+            if "diarization" in request.wants:
+                segment["speaker"] = item["speaker"]
+            if "word_timestamps" in request.wants and "words" in item:
+                words = []
+                for word in item["words"]:
+                    words.append({"word_id": f"w_{word_index}", **word})
+                    word_index += 1
+                segment["words"] = words
+            segments.append(segment)
+
+        incomplete = bool(unfinished)
+        coverage: Any = ABSENT
+        if incomplete:
+            coverage = _coverage(
+                unfinished, total_units=len(selected_units), completed_units=len(completed),
+                scope_start=scope_start, scope_end=scope_end,
+            )
+        if incomplete:
+            # Coverage stays at selected unit bounds, but whole-source auxiliary stages can
+            # observe evidence between a hand-written range start and the first selected turn.
+            # The partial document owns that leading gap; the next resume begins at watermark.
+            selected_scope = (
+                min(requested_start, scope_start), coverage["covered_through_seconds"]
+            )
+        elif run_range is not None:
+            # A requested interval can extend beyond the first/last selected turn, while a
+            # fixed processing unit can extend beyond an explicit bound. Own both extents so
+            # auxiliary evidence is neither lost at a diarized tail nor clipped from a selected
+            # whole unit. Resume watermarks are unit boundaries, preserving disjoint documents.
+            selected_scope = (
+                min(requested_start, scope_start), max(requested_end, scope_end)
+            )
+        else:
+            selected_scope = None
+
+        turns: Any = ABSENT
+        overlaps: Any = ABSENT
+        abstentions = []
+        if diarization is not None:
+            if "diarization" in request.wants:
+                turns = [item for item in diarization.turns if item["turn_id"] in completed_ids]
+            for reason, spans in (
+                ("raw_fragment", diarization.raw_fragments),
+                ("short_turn", diarization.short_turns),
+            ):
+                for span in spans:
+                    if not _span_owned(
+                        span, scope=selected_scope
+                    ):
+                        continue
+                    abstentions.append({
+                        "abstention_id": f"ab_{len(abstentions)}",
+                        "reason": reason,
+                        **span,
+                    })
+            owned_overlaps = [
+                span for span in diarization.overlaps
+                if _span_owned(span, scope=selected_scope)
+            ]
+            if "overlapped_speech" in request.wants:
+                overlaps = [{"overlap_id": f"overlap_{index}", **span}
+                            for index, span in enumerate(owned_overlaps)]
+            for span in owned_overlaps:
+                abstentions.append({
+                    "abstention_id": f"ab_{len(abstentions)}", "reason": "overlap", **span,
+                })
+
+        if vad_regions is not ABSENT:
+            vad_regions = [
+                span for span in vad_regions
+                if _span_owned(span, scope=selected_scope)
+            ]
+        abstentions.sort(key=lambda item: (
+            float(item["start"]), float(item["end"]), str(item["reason"])
+        ))
+        for index, item in enumerate(abstentions):
+            item["abstention_id"] = f"ab_{index}"
+        executed_plan = _core_plan(plan)
+        if run_range is not None:
+            executed_plan["execution"]["range"] = {
+                "requested": [requested_start, requested_end],
+                "selected_unit_scope": [scope_start, scope_end],
+            }
+        source = dict(metadata.source)
+        source["duration_seconds"] = canonical_duration
+        normalized = NormalizedResult(
+            source=source,
+            segments=segments,
+            abstentions=abstentions,
+            provenance={
+                "stack": request.stack.id,
+                "outcomes": _outcomes(
+                    request.wants,
+                    segments=segments,
+                ),
+                "observed": {},
+                "plan": executed_plan,
+            },
+            requested_capabilities=frozenset(request.wants),
+            complete=not incomplete,
+            coverage=coverage,
+            turns=turns,
+            vad_regions=vad_regions,
+            overlapped_speech=overlaps,
+        )
+        normalized.provenance["observed"].update(_record_metrics(outcomes, normalized))
+        try:
+            payload = serialize_result(normalized)
+        except ResultError as exc:
+            raise refusals.backend_failed(
+                active_role,
+                active_backend,
+                str(exc),
+                _backend_fix(active_role, active_backend),
+            ) from exc
+
+    if incomplete:
+        target = _partial_path(request.input_path, output)
+        if output is None and target.exists() and not force:
+            target = _unused_partial_path(request.input_path)
+        atomic_write_json(target, payload)
+        stage_error = asr.payload.get("error", {})
+        detail = stage_error.get("message") if isinstance(stage_error, Mapping) else None
+        raise refusals.run_incomplete(
+            "asr", asr_backend,
+            str(detail) if detail else
+            f"global generation budget exhausted after {len(completed)} of "
+            f"{len(selected_units)} units",
+            coverage,
+            target,
+            _resume_command(request, coverage, target, run_range),
+        )
+    if output is not None:
+        if output_format == "json":
+            atomic_write_json(output, payload)
+        else:
+            _atomic_write_text(output, render_human(payload, output_format))
+    return RunProduct(payload)

--- a/src/audio_cli/transcribe/planner.py
+++ b/src/audio_cli/transcribe/planner.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Iterable
 from dataclasses import dataclass
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from audio_cli import environments as env
 
@@ -36,10 +37,8 @@ _FLUIDAUDIO = {
     "revision": "19600a485baa4998812e4654b70d2bab8f2c9949",
     "environment": "swift",
     "config": {
-        "preset": "quality",
         "step_ratio": 0.1,
         "min_segment_duration": 0.0,
-        "output": "regular",
         "threshold": 0.6,
         "batch_size": 32,
     },

--- a/src/audio_cli/transcribe/refusals.py
+++ b/src/audio_cli/transcribe/refusals.py
@@ -50,6 +50,41 @@ def _plan_command(
     return shlex.join(parts)
 
 
+def _run_command(
+    input_path: str | Path,
+    stack: str,
+    wants: Sequence[str] = (),
+    *,
+    language: str | None = None,
+    vad: str | None = None,
+    diarizer: str | None = None,
+    run_range: str | None = None,
+    output_format: str = "json",
+    output: str | Path | None = None,
+    force: bool = False,
+) -> str:
+    parts = [
+        "audio", "transcribe", "run", "--input", str(input_path), "--stack", stack,
+    ]
+    if wants:
+        parts.extend(("--want", ",".join(wants)))
+    if language is not None:
+        parts.extend(("--language", language))
+    if vad is not None:
+        parts.extend(("--vad", vad))
+    if diarizer is not None:
+        parts.extend(("--diarizer", diarizer))
+    if run_range is not None:
+        parts.extend(("--range", run_range))
+    if output_format != "json":
+        parts.extend(("--format", output_format))
+    if output is not None:
+        parts.extend(("-o", str(output)))
+    if force:
+        parts.append("--force")
+    return shlex.join(parts)
+
+
 def stack_required(input_path: str | Path | None, wants: Sequence[str]) -> Refusal:
     chosen_input = input_path or "meeting.m4a"
     return _refusal(
@@ -212,6 +247,90 @@ def pin_conflicts_with_native_capability(
     )
 
 
+def range_invalid(
+    input_path: str | Path,
+    stack: str,
+    wants: Sequence[str],
+    provided: str,
+    reason: str,
+    *,
+    language: str | None = None,
+    vad: str | None = None,
+    diarizer: str | None = None,
+) -> Refusal:
+    return _refusal(
+        "range_invalid",
+        2,
+        _run_command(
+            input_path, stack, wants, language=language, vad=vad, diarizer=diarizer
+        ),
+        field="--range",
+        provided=provided,
+        reason=reason,
+    )
+
+
+def output_exists(
+    input_path: str | Path,
+    stack: str,
+    wants: Sequence[str],
+    output: str | Path,
+    existing: str | Path,
+    *,
+    language: str | None = None,
+    vad: str | None = None,
+    diarizer: str | None = None,
+    run_range: str | None = None,
+    output_format: str = "json",
+) -> Refusal:
+    return _refusal(
+        "output_exists",
+        2,
+        _run_command(
+            input_path,
+            stack,
+            wants,
+            language=language,
+            vad=vad,
+            diarizer=diarizer,
+            run_range=run_range,
+            output_format=output_format,
+            output=output,
+            force=True,
+        ),
+        field="--output",
+        provided=str(output),
+        existing=str(existing),
+    )
+
+
+def output_is_canonical_input(
+    output: str | Path, resolved_target: str | Path,
+) -> Refusal:
+    return _refusal(
+        "output_is_canonical_input",
+        2,
+        (
+            "choose an --output whose transcript and derived partial paths do not resolve "
+            "to the canonical input; --force cannot override this"
+        ),
+        field="--output",
+        provided=str(output),
+        resolved_target=str(resolved_target),
+    )
+
+
+def stack_run_unavailable(stack: str, issue: int) -> Refusal:
+    return _refusal(
+        "stack_run_unavailable",
+        2,
+        f"the {stack} run adapter is tracked in "
+        f"https://github.com/fyang0507/audio-processing-cli/issues/{issue}",
+        stack=stack,
+        issue=issue,
+    )
+
+
 def timing_required_for_format(
     input_path: str | Path,
     output_format: str,
@@ -237,7 +356,7 @@ def timing_required_for_format(
 
 def packages_not_provisioned(
     stack: str,
-    missing: Sequence[str],
+    missing: Sequence[Mapping[str, Any]],
     total_known_download_bytes: int,
     unsized_packages: Sequence[str],
 ) -> Refusal:

--- a/src/audio_cli/transcribe/result.py
+++ b/src/audio_cli/transcribe/result.py
@@ -11,6 +11,7 @@ import json
 import math
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from itertools import pairwise
 from typing import Any
 
 SCHEMA_VERSION = 1
@@ -123,7 +124,9 @@ def _validate_source(source: JsonMapping) -> float:
     return duration
 
 
-def _validate_bounds(item: JsonMapping, field: str, *, sample: bool) -> None:
+def _validate_bounds(
+    item: JsonMapping, field: str, *, sample: bool, duration: float
+) -> None:
     has_start = "start" in item
     has_end = "end" in item
     if has_start != has_end:
@@ -137,11 +140,15 @@ def _validate_bounds(item: JsonMapping, field: str, *, sample: bool) -> None:
             raise ResultError(f"{field} placeholder bounds must be null")
         return
     assert start is not None and end is not None
-    if start < 0 or end < start:
-        raise ResultError(f"{field} bounds must satisfy 0 <= start <= end")
+    if start < 0 or end < start or end > duration:
+        raise ResultError(
+            f"{field} bounds must satisfy 0 <= start <= end <= source duration"
+        )
 
 
-def _validate_words(words: object, field: str, *, sample: bool) -> None:
+def _validate_words(
+    words: object, field: str, *, sample: bool, duration: float
+) -> None:
     if not isinstance(words, (list, tuple)):
         raise ResultError(f"{field} must be an array")
     for index, word in enumerate(words):
@@ -156,7 +163,7 @@ def _validate_words(words: object, field: str, *, sample: bool) -> None:
                 raise ResultError(f"{name}.text placeholder must be null")
         elif not isinstance(word["text"], str):
             raise ResultError(f"{name}.text must be a string")
-        _validate_bounds(word, name, sample=sample)
+        _validate_bounds(word, name, sample=sample, duration=duration)
 
 
 def _validate_segments(
@@ -164,6 +171,7 @@ def _validate_segments(
     requested: frozenset[str],
     *,
     sample: bool,
+    duration: float,
 ) -> None:
     for index, segment in enumerate(segments):
         if not isinstance(segment, Mapping):
@@ -193,8 +201,10 @@ def _validate_segments(
             if not sample and not isinstance(segment["speaker"], str):
                 raise ResultError(f"{field}.speaker must be a string when present")
         if "words" in segment:
-            _validate_words(segment["words"], f"{field}.words", sample=sample)
-        _validate_bounds(segment, field, sample=sample)
+            _validate_words(
+                segment["words"], f"{field}.words", sample=sample, duration=duration
+            )
+        _validate_bounds(segment, field, sample=sample, duration=duration)
 
 
 def _validate_span_array(
@@ -203,13 +213,14 @@ def _validate_span_array(
     expected: set[str],
     *,
     sample: bool,
+    duration: float,
 ) -> None:
     for index, item in enumerate(values):
         if not isinstance(item, Mapping):
             raise ResultError(f"{field}[{index}] must be an object")
         name = f"{field}[{index}]"
         _exact_keys(item, expected, name)
-        _validate_bounds(item, name, sample=sample)
+        _validate_bounds(item, name, sample=sample, duration=duration)
         for key in expected - {"start", "end"}:
             value = item[key]
             if sample and key not in {"turn_id", "overlap_id"} and value is not None:
@@ -233,9 +244,9 @@ def _validate_span_array(
 
 def _validate_abstentions(
     values: Sequence[JsonMapping],
-    requested: frozenset[str],
     *,
     sample: bool,
+    duration: float,
 ) -> None:
     for index, item in enumerate(values):
         if not isinstance(item, Mapping):
@@ -248,12 +259,7 @@ def _validate_abstentions(
             raise ResultError(
                 f"{name}.reason must be one of {sorted(ABSTENTION_REASONS)}"
             )
-        if item["reason"] in {"raw_fragment", "short_turn"} \
-                and "diarization" not in requested:
-            raise ResultError(f"{name}.reason {item['reason']!r} requires diarization")
-        if item["reason"] == "overlap" and "overlapped_speech" not in requested:
-            raise ResultError(f"{name}.reason 'overlap' requires overlapped_speech")
-        _validate_bounds(item, name, sample=sample)
+        _validate_bounds(item, name, sample=sample, duration=duration)
 
 
 def _validate_coverage(coverage: JsonMapping, *, duration: float) -> None:
@@ -264,6 +270,7 @@ def _validate_coverage(coverage: JsonMapping, *, duration: float) -> None:
             "covered_fraction",
             "covered_intervals",
             "missing_intervals",
+            "scope_intervals",
             "units_total",
             "units_completed",
         },
@@ -283,7 +290,7 @@ def _validate_coverage(coverage: JsonMapping, *, duration: float) -> None:
     if coverage["units_completed"] > coverage["units_total"]:
         raise ResultError("coverage.units_completed exceeds coverage.units_total")
     parsed: dict[str, list[tuple[float, float]]] = {}
-    for key in ("covered_intervals", "missing_intervals"):
+    for key in ("scope_intervals", "covered_intervals", "missing_intervals"):
         intervals = coverage[key]
         if not isinstance(intervals, (list, tuple)):
             raise ResultError(f"coverage.{key} must be an array")
@@ -298,24 +305,39 @@ def _validate_coverage(coverage: JsonMapping, *, duration: float) -> None:
                 raise ResultError(f"coverage.{key}[{index}] is not an ordered interval")
             parsed[key].append((start, end))
 
-    if duration == 0 or not parsed["missing_intervals"]:
+    if duration == 0 or not parsed["scope_intervals"] or not parsed["missing_intervals"]:
         raise ResultError("an incomplete result must have non-empty missing intervals")
     first_missing = min(start for start, _ in parsed["missing_intervals"])
     if not math.isclose(watermark, first_missing, abs_tol=1e-6):
         raise ResultError("covered_through_seconds must equal the first missing interval start")
 
+    scopes = parsed["scope_intervals"]
+    for left, right in pairwise(scopes):
+        if left[1] > right[0]:
+            raise ResultError("coverage scope intervals must not overlap")
     tiled = sorted(parsed["covered_intervals"] + parsed["missing_intervals"])
-    cursor = 0.0
-    for start, end in tiled:
-        if not math.isclose(start, cursor, abs_tol=1e-6):
-            raise ResultError("covered and missing intervals must tile the source without gaps")
-        cursor = end
-    if not math.isclose(cursor, duration, abs_tol=1e-6):
-        raise ResultError("covered and missing intervals must tile the complete source")
+    interval_index = 0
+    for scope_start, scope_end in scopes:
+        cursor = scope_start
+        while interval_index < len(tiled) and tiled[interval_index][0] < scope_end:
+            start, end = tiled[interval_index]
+            if not math.isclose(start, cursor, abs_tol=1e-6) or end > scope_end:
+                raise ResultError(
+                    "covered and missing intervals must tile the coverage scope without gaps"
+                )
+            cursor = end
+            interval_index += 1
+        if not math.isclose(cursor, scope_end, abs_tol=1e-6):
+            raise ResultError(
+                "covered and missing intervals must tile the coverage scope without gaps"
+            )
+    if interval_index != len(tiled):
+        raise ResultError("covered and missing intervals must stay inside the coverage scope")
 
     covered_seconds = sum(end - start for start, end in parsed["covered_intervals"])
-    if not math.isclose(fraction, covered_seconds / duration, abs_tol=0.0005):
-        raise ResultError("covered_fraction must equal covered duration over source duration")
+    scope_seconds = sum(end - start for start, end in scopes)
+    if not math.isclose(fraction, covered_seconds / scope_seconds, abs_tol=0.0005):
+        raise ResultError("covered_fraction must equal covered duration over coverage scope")
     if coverage["units_completed"] >= coverage["units_total"]:
         raise ResultError("an incomplete result must leave at least one unit incomplete")
 
@@ -389,10 +411,10 @@ def _validate_observed(observed: Mapping[str, Any], result: NormalizedResult) ->
     expected_counts = {
         "segments": len(result.segments),
         "words": sum(len(segment.get("words", [])) for segment in result.segments),
-        "turns": count_array(result.turns),
-        "segments_without_words": sum(
-            1 for segment in result.segments if not segment.get("words")
-        ),
+            "turns": count_array(result.turns),
+            "segments_without_words": sum(
+                1 for segment in result.segments if "words" not in segment
+            ),
         "abstentions": len(result.abstentions),
         "vad_regions": count_array(result.vad_regions),
         "lid_regions": count_array(result.lid_regions),
@@ -471,8 +493,12 @@ def serialize_result(result: NormalizedResult) -> dict[str, Any]:
     if has_coverage:
         assert isinstance(result.coverage, Mapping)
         _validate_coverage(result.coverage, duration=duration)
-    _validate_segments(result.segments, requested, sample=result.sample)
-    _validate_abstentions(result.abstentions, requested, sample=result.sample)
+    _validate_segments(
+        result.segments, requested, sample=result.sample, duration=duration
+    )
+    _validate_abstentions(
+        result.abstentions, sample=result.sample, duration=duration
+    )
     _validate_provenance(result.provenance, requested, result, sample=result.sample)
 
     arrays = {
@@ -494,7 +520,7 @@ def serialize_result(result: NormalizedResult) -> dict[str, Any]:
             if not isinstance(value, (list, tuple)):
                 raise ResultError(f"{field} must be an array")
             _validate_span_array(
-                value, field, expected_keys, sample=result.sample
+                value, field, expected_keys, sample=result.sample, duration=duration
             )
 
     payload: dict[str, Any] = {}

--- a/src/audio_cli/transcribe/stages/__init__.py
+++ b/src/audio_cli/transcribe/stages/__init__.py
@@ -1,0 +1,1 @@
+"""Environment-isolated stage entry points shipped with the wheel."""

--- a/src/audio_cli/transcribe/stages/aligner.py
+++ b/src/audio_cli/transcribe/stages/aligner.py
@@ -1,0 +1,94 @@
+"""Execute forced alignment per segment without importing the core CLI package."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import resource
+import sys
+import time
+import traceback
+from pathlib import Path
+
+CJK = re.compile(r"[一-鿿]")
+
+
+def _rss_bytes() -> int:
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def main() -> int:
+    request_path, result_path = map(Path, sys.argv[1:3])
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    started = time.perf_counter()
+    output = {"segments": [], "metrics": {}}
+    try:
+        for name in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
+            os.environ[name] = "1"
+
+        print("aligner stage: loading local model", file=sys.stderr, flush=True)
+        import mlx.core as mx
+        import numpy as np
+        from mlx_audio.audio_io import read as audio_read
+        from mlx_audio.stt import load as stt_load
+
+        raw_audio, rate = audio_read(Path(request["audio"]), always_2d=True, dtype="float32")
+        if rate != 16_000 or raw_audio.shape[1] != 1:
+            raise ValueError(f"canonical input must be mono 16000 Hz, got {rate} Hz")
+        audio = np.ascontiguousarray(raw_audio[:, 0], dtype=np.float32)
+        model = stt_load(Path(request["model"]))
+        for index, segment in enumerate(request["segments"]):
+            text = segment["text"]
+            start_s, end_s = float(segment["start"]), float(segment["end"])
+            clip = audio[round(start_s * rate):round(end_s * rate)]
+            language = "Chinese" if CJK.search(text) else "English"
+            print(
+                f"aligner stage: processing segment {index + 1}/"
+                f"{len(request['segments'])}",
+                file=sys.stderr,
+                flush=True,
+            )
+            try:
+                generated = model.generate(audio=clip, text=text, language=language)
+                output["segments"].append({
+                    "unit_id": segment["unit_id"],
+                    "language": language,
+                    "words": [{
+                        "text": item.text,
+                        "start": round(float(item.start_time) + start_s, 3),
+                        "end": round(float(item.end_time) + start_s, 3),
+                    } for item in generated],
+                })
+            except Exception as exc:  # noqa: BLE001 - this capability may abstain per segment
+                output["segments"].append({
+                    "unit_id": segment["unit_id"],
+                    "language": language,
+                    "words": None,
+                    "error": {"type": type(exc).__name__, "message": str(exc)},
+                })
+        output["metrics"] = {
+            "wall_seconds": round(time.perf_counter() - started, 6),
+            "peak_rss_bytes": _rss_bytes(),
+            "peak_mps_live_bytes": int(mx.get_peak_memory()),
+        }
+        code = 0
+    except Exception as exc:  # noqa: BLE001 - the stage must always write a result envelope
+        output["error"] = {
+            "type": type(exc).__name__, "message": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        output["metrics"] = {
+            "wall_seconds": round(time.perf_counter() - started, 6),
+            "peak_rss_bytes": _rss_bytes(),
+        }
+        code = 1
+    result_path.write_text(
+        json.dumps(output, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/audio_cli/transcribe/stages/qwen.py
+++ b/src/audio_cli/transcribe/stages/qwen.py
@@ -1,0 +1,124 @@
+"""Execute one Qwen ASR request. This file intentionally depends on no core package code."""
+
+from __future__ import annotations
+
+import json
+import os
+import resource
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+def _rss_bytes() -> int:
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def main() -> int:
+    request_path, result_path = map(Path, sys.argv[1:3])
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    started = time.perf_counter()
+    units = request["units"]
+    output = {"units": [], "metrics": {}}
+    raw_by_index = {}
+    mx = None
+    try:
+        for name in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "HF_DATASETS_OFFLINE"):
+            os.environ[name] = "1"
+
+        print("qwen stage: loading local model", file=sys.stderr, flush=True)
+        import mlx.core as mx
+        import numpy as np
+        from mlx_audio.audio_io import read as audio_read
+        from mlx_audio.stt.utils import load_model
+        from mlx_lm.sample_utils import make_sampler
+
+        raw_audio, rate = audio_read(Path(request["audio"]), always_2d=True, dtype="float32")
+        if rate != 16_000 or raw_audio.shape[1] != 1:
+            raise ValueError(f"canonical input must be mono 16000 Hz, got {rate} Hz")
+        audio = np.ascontiguousarray(raw_audio[:, 0], dtype=np.float32)
+        model = load_model(Path(request["model"]), lazy=False, strict=False)
+        mx.eval(model.parameters())
+        mx.synchronize()
+        method = model._generate_chunks_batched
+        order = sorted(range(len(units)), key=lambda i: (
+            round((float(units[i]["end"]) - float(units[i]["start"])) * 16_000), i
+        ))
+        remaining = int(request["max_tokens"])
+        batch_size = int(request["batch_size"])
+        if batch_size < 1:
+            raise ValueError("batch_size must be positive")
+        for offset in range(0, len(order), batch_size):
+            if remaining <= 0:
+                break
+            indices = order[offset:offset + batch_size]
+            clips = []
+            for index in indices:
+                unit = units[index]
+                start = max(0, round(float(unit["start"]) * 16_000))
+                end = min(len(audio), round(float(unit["end"]) * 16_000))
+                clips.append((audio[start:end], 0.0))
+            print(
+                f"qwen stage: processing batch {offset // batch_size + 1} "
+                f"({len(indices)} unit(s))",
+                file=sys.stderr,
+                flush=True,
+            )
+            texts, generated, prompts, processed = method(
+                clips,
+                max_tokens=remaining,
+                sampler=make_sampler(temp=0.0),
+                language=request.get("language"),
+                system_prompt=None,
+                batch_size=batch_size,
+                verbose=False,
+            )
+            if not all(len(values) == len(indices) for values in (
+                texts, generated, prompts, processed
+            )) or not all(isinstance(value, bool) for value in processed):
+                raise TypeError("private batched API returned inconsistent per-unit results")
+            for local_index, index in enumerate(indices):
+                unit = units[index]
+                raw_by_index[index] = {
+                    "unit_id": unit["unit_id"], "text": texts[local_index],
+                    "processed": processed[local_index],
+                    "prompt_tokens": int(prompts[local_index]),
+                    "generation_tokens": int(generated[local_index]),
+                }
+            remaining -= sum(int(value) for value in generated)
+            if request["clear_cache_after_every_batch"]:
+                mx.clear_cache()
+                mx.synchronize()
+        code = 0
+    except Exception as exc:  # noqa: BLE001 - the stage must always write a result envelope
+        output["error"] = {
+            "type": type(exc).__name__, "message": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        code = 4 if any(item.get("processed") for item in raw_by_index.values()) else 1
+    for index, unit in enumerate(units):
+        output["units"].append(raw_by_index.get(index, {
+            "unit_id": unit["unit_id"], "text": "", "processed": False,
+            "prompt_tokens": 0, "generation_tokens": 0,
+        }))
+    output["metrics"] = {
+        "wall_seconds": round(time.perf_counter() - started, 6),
+        "peak_rss_bytes": _rss_bytes(),
+    }
+    if mx is not None:
+        try:
+            output["metrics"]["peak_mps_live_bytes"] = int(mx.get_peak_memory())
+        except Exception:  # noqa: BLE001, S110 - an optional metric cannot suppress the result
+            pass
+    if code == 0 and not all(item["processed"] for item in output["units"]):
+        code = 4
+    result_path.write_text(
+        json.dumps(output, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/audio_cli/transcribe/transport.py
+++ b/src/audio_cli/transcribe/transport.py
@@ -1,0 +1,365 @@
+"""Strictly sequential, fresh-process transport for transcription stages."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from audio_cli import paths
+
+from .adapters.decode import command as decode_command
+
+
+@dataclass(frozen=True)
+class StageOutcome:
+    role: str
+    backend: str
+    payload: dict[str, Any]
+    wall_seconds: float
+    returncode: int = 0
+    peak_rss_bytes: int | None = None
+    peak_mps_live_bytes: int | None = None
+
+
+class StageFailure(RuntimeError):
+    def __init__(self, role: str, backend: str, detail: str) -> None:
+        self.role = role
+        self.backend = backend
+        self.detail = detail
+        super().__init__(detail)
+
+
+class ProcessRunner(Protocol):
+    def run(self, command: list[str]) -> subprocess.CompletedProcess[str]: ...
+
+
+class _MacProcTaskInfo(ctypes.Structure):
+    _fields_ = [
+        ("virtual_size", ctypes.c_uint64),
+        ("resident_size", ctypes.c_uint64),
+        ("total_user", ctypes.c_uint64),
+        ("total_system", ctypes.c_uint64),
+        ("threads_user", ctypes.c_uint64),
+        ("threads_system", ctypes.c_uint64),
+        ("policy", ctypes.c_int32),
+        ("faults", ctypes.c_int32),
+        ("pageins", ctypes.c_int32),
+        ("cow_faults", ctypes.c_int32),
+        ("messages_sent", ctypes.c_int32),
+        ("messages_received", ctypes.c_int32),
+        ("syscalls_mach", ctypes.c_int32),
+        ("syscalls_unix", ctypes.c_int32),
+        ("context_switches", ctypes.c_int32),
+        ("thread_count", ctypes.c_int32),
+        ("running_threads", ctypes.c_int32),
+        ("priority", ctypes.c_int32),
+    ]
+
+
+class _ChildRssReader:
+    """Read a child process's current RSS without launching another process."""
+
+    def __init__(self) -> None:
+        self._proc_pidinfo = None
+        if sys.platform == "darwin":
+            try:
+                function = ctypes.CDLL(
+                    "/usr/lib/libproc.dylib", use_errno=True
+                ).proc_pidinfo
+                function.argtypes = [
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_uint64,
+                    ctypes.c_void_p,
+                    ctypes.c_int,
+                ]
+                function.restype = ctypes.c_int
+                self._proc_pidinfo = function
+            except OSError:
+                pass
+
+    def read(self, pid: int) -> int | None:
+        if self._proc_pidinfo is not None:
+            info = _MacProcTaskInfo()
+            returned = self._proc_pidinfo(
+                pid, 4, 0, ctypes.byref(info), ctypes.sizeof(info)
+            )
+            if returned == ctypes.sizeof(info):
+                return int(info.resident_size)
+        try:
+            resident_pages = int(
+                Path(f"/proc/{pid}/statm").read_text(encoding="utf-8").split()[1]
+            )
+            return resident_pages * os.sysconf("SC_PAGE_SIZE")
+        except (OSError, ValueError, IndexError):
+            return None
+
+
+class SubprocessRunner:
+    def __init__(self, progress) -> None:
+        self.progress = progress
+
+    def run(self, command: list[str]) -> subprocess.CompletedProcess[str]:
+        try:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+        except OSError as exc:
+            return subprocess.CompletedProcess(command, 127, "", str(exc))
+
+        stdout: list[str] = []
+        stderr: list[str] = []
+
+        def drain(stream, sink: list[str], *, mirror: bool = False) -> None:
+            for line in iter(stream.readline, ""):
+                sink.append(line)
+                if mirror:
+                    self.progress.write(line)
+                    self.progress.flush()
+            stream.close()
+
+        assert process.stdout is not None and process.stderr is not None
+        stdout_thread = threading.Thread(target=drain, args=(process.stdout, stdout))
+        stderr_thread = threading.Thread(
+            target=drain, args=(process.stderr, stderr), kwargs={"mirror": True}
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        reader = _ChildRssReader()
+        peak_rss: int | None = None
+        while process.poll() is None:
+            sample = reader.read(process.pid)
+            if sample is not None:
+                peak_rss = sample if peak_rss is None else max(peak_rss, sample)
+            time.sleep(0.01)
+        stdout_thread.join()
+        stderr_thread.join()
+        completed = subprocess.CompletedProcess(
+            command, process.returncode, "".join(stdout), "".join(stderr)
+        )
+        completed.peak_rss_bytes = peak_rss  # type: ignore[attr-defined]
+        completed.stderr_streamed = True  # type: ignore[attr-defined]
+        return completed
+
+
+class StageTransport:
+    """Launch each non-core stage exactly once, never keeping a model resident."""
+
+    def __init__(self, runner: ProcessRunner | None = None, *, progress=None) -> None:
+        self.progress = progress or sys.stderr
+        self.runner = runner or SubprocessRunner(self.progress)
+
+    def _notice(self, message: str) -> None:
+        self.progress.write(message + "\n")
+        self.progress.flush()
+
+    def decode(self, source: Path, target: Path) -> StageOutcome:
+        self._notice("transcribe: decode started")
+        started = time.perf_counter()
+        completed = self.runner.run(decode_command(source, target))
+        wall = time.perf_counter() - started
+        if completed.returncode != 0 or not target.is_file():
+            detail = completed.stderr.strip() or "ffmpeg did not write the canonical WAV"
+            raise StageFailure("decode", "ffmpeg", detail[-4000:])
+        self._notice("transcribe: decode finished")
+        return StageOutcome(
+            "decode",
+            "ffmpeg",
+            {},
+            round(wall, 6),
+            peak_rss_bytes=getattr(completed, "peak_rss_bytes", None),
+        )
+
+    @staticmethod
+    def _stage_script(name: str, role: str, backend: str) -> Path:
+        target = Path(__file__).resolve().parent / "stages" / f"{name}.py"
+        if not target.is_file():
+            raise StageFailure(role, backend, f"installed stage script is missing: {target}")
+        return target
+
+    def _json_stage(
+        self,
+        *,
+        role: str,
+        backend: str,
+        environment: str,
+        script: str,
+        request: dict[str, Any],
+        directory: Path,
+    ) -> StageOutcome:
+        request_path = directory / f"{role}.request.json"
+        result_path = directory / f"{role}.result.json"
+        request_path.write_text(
+            json.dumps(request, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+        command = [
+            str(paths.env_python(environment)),
+            str(self._stage_script(script, role, backend)),
+            str(request_path),
+            str(result_path),
+        ]
+        self._notice(f"transcribe: {role} started ({backend})")
+        started = time.perf_counter()
+        completed = self.runner.run(command)
+        transport_wall = time.perf_counter() - started
+        if completed.stderr and not getattr(completed, "stderr_streamed", False):
+            self.progress.write(completed.stderr)
+            if not completed.stderr.endswith("\n"):
+                self.progress.write("\n")
+        if not result_path.is_file():
+            detail = completed.stderr.strip() or f"stage exited {completed.returncode} without a result"
+            raise StageFailure(role, backend, detail[-4000:])
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise StageFailure(role, backend, f"stage result is invalid JSON: {exc}") from exc
+        metrics = payload.get("metrics", {})
+        wall = float(metrics.get("wall_seconds", transport_wall))
+        outcome = StageOutcome(
+            role,
+            backend,
+            payload,
+            round(wall, 6),
+            completed.returncode,
+            max(
+                value for value in (
+                    int(metrics["peak_rss_bytes"])
+                    if metrics.get("peak_rss_bytes") is not None else None,
+                    getattr(completed, "peak_rss_bytes", None),
+                ) if value is not None
+            ) if metrics.get("peak_rss_bytes") is not None
+            or getattr(completed, "peak_rss_bytes", None) is not None else None,
+            int(metrics["peak_mps_live_bytes"])
+            if metrics.get("peak_mps_live_bytes") is not None else None,
+        )
+        if completed.returncode not in {0, 4}:
+            error = payload.get("error", {})
+            detail = error.get("message") or completed.stderr.strip() or f"stage exited {completed.returncode}"
+            raise StageFailure(role, backend, str(detail)[-4000:])
+        self._notice(
+            f"transcribe: {role} {'incomplete' if completed.returncode == 4 else 'finished'}"
+        )
+        return outcome
+
+    def qwen(
+        self,
+        *,
+        backend: str,
+        model: Path,
+        audio: Path,
+        units: list[dict[str, Any]],
+        language: str | None,
+        max_tokens: int,
+        batch_size: int,
+        clear_cache_after_every_batch: bool,
+        directory: Path,
+    ) -> StageOutcome:
+        return self._json_stage(
+            role="asr",
+            backend=backend,
+            environment="mlx",
+            script="qwen",
+            request={
+                "model": str(model), "audio": str(audio), "units": units,
+                "language": language, "max_tokens": max_tokens,
+                "batch_size": batch_size,
+                "clear_cache_after_every_batch": clear_cache_after_every_batch,
+            },
+            directory=directory,
+        )
+
+    def align(
+        self,
+        *,
+        model: Path,
+        audio: Path,
+        segments: list[dict[str, Any]],
+        directory: Path,
+    ) -> StageOutcome:
+        return self._json_stage(
+            role="aligner",
+            backend="qwen3-forcedaligner",
+            environment="mlx",
+            script="aligner",
+            request={"model": str(model), "audio": str(audio), "segments": segments},
+            directory=directory,
+        )
+
+    @staticmethod
+    def _swift_product(checkout: Path, product: str) -> Path:
+        candidates = sorted(checkout.glob(f".build/**/release/{product}"))
+        candidates.extend(sorted(checkout.glob(f".build/release/{product}")))
+        unique = list(dict.fromkeys(path.resolve() for path in candidates if path.is_file()))
+        if len(unique) != 1:
+            raise StageFailure(
+                "diarizer", "fluidaudio",
+                f"expected one built {product!r} under {checkout / '.build'}, found {len(unique)}",
+            )
+        return unique[0]
+
+    def diarize(
+        self,
+        *,
+        checkout: Path,
+        product: str,
+        audio: Path,
+        config: dict[str, Any],
+        overlap: bool,
+        directory: Path,
+    ) -> StageOutcome:
+        raw_path = directory / "diarizer.result.json"
+        command = [
+            str(self._swift_product(checkout, product)),
+            "process",
+            str(audio),
+            "--mode",
+            "offline",
+            "--output",
+            str(raw_path),
+            "--threshold",
+            str(config["threshold"]),
+            "--step-ratio",
+            str(config["step_ratio"]),
+            "--min-segment-duration",
+            str(config["min_segment_duration"]),
+            "--batch-size",
+            str(config["batch_size"]),
+        ]
+        if overlap:
+            command.append("--overlapping-segments")
+        self._notice("transcribe: diarizer started (fluidaudio)")
+        started = time.perf_counter()
+        completed = self.runner.run(command)
+        wall = time.perf_counter() - started
+        if completed.stderr and not getattr(completed, "stderr_streamed", False):
+            self.progress.write(completed.stderr)
+            if not completed.stderr.endswith("\n"):
+                self.progress.write("\n")
+        if completed.returncode != 0 or not raw_path.is_file():
+            detail = completed.stderr.strip() or f"FluidAudio exited {completed.returncode}"
+            raise StageFailure("diarizer", "fluidaudio", detail[-4000:])
+        try:
+            payload = json.loads(raw_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise StageFailure("diarizer", "fluidaudio", f"invalid result JSON: {exc}") from exc
+        self._notice("transcribe: diarizer finished")
+        return StageOutcome(
+            "diarizer",
+            "fluidaudio",
+            payload,
+            round(wall, 6),
+            peak_rss_bytes=getattr(completed, "peak_rss_bytes", None),
+        )

--- a/tests/test_shipped_commands_match_the_document.py
+++ b/tests/test_shipped_commands_match_the_document.py
@@ -22,16 +22,20 @@ from __future__ import annotations
 
 import json
 import re
+import wave
 from pathlib import Path
 
 import pytest
 
 from audio_cli import environments as env
 from audio_cli import packages as pkg
+from audio_cli.transcribe import refusals
 from audio_cli.transcribe.catalog import InputMetadata, build_catalog
+from audio_cli.transcribe.orchestrator import run
 from audio_cli.transcribe.plan import serialize_plan
 from audio_cli.transcribe.planner import build_plan, resolve_request
 from audio_cli.transcribe.stacks import get_stack
+from audio_cli.transcribe.transport import StageOutcome
 
 REPO = Path(__file__).resolve().parents[1]
 HAPPY_PATH = REPO / "TRANSCRIBE_HAPPY_PATH.md"
@@ -344,3 +348,141 @@ def test_transcribe_plan_emits_the_shape_happy_path_publishes(
             actual["capabilities"]["vad"]["note"]
             == documented["capabilities"]["vad"]["note"]
         )
+
+
+def test_qwen_run_emits_the_shape_happy_path_publishes(tmp_path) -> None:
+    interpreter = tmp_path / "root" / "envs" / "mlx" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+
+    class Transport:
+        def decode(self, source, target):
+            with wave.open(str(target), "wb") as handle:
+                handle.setnchannels(1)
+                handle.setsampwidth(2)
+                handle.setframerate(16_000)
+                handle.writeframes(b"\0\0" * (120 * 16_000))
+            return StageOutcome("decode", "ffmpeg", {}, 1.0, peak_rss_bytes=50)
+
+        def diarize(self, **kwargs):
+            return StageOutcome("diarizer", "fluidaudio", {"segments": [
+                {"start_s": 2.28, "end_s": 4.79, "speaker": "S1"},
+                {"start_s": 5.06, "end_s": 7.51, "speaker": "S2"},
+                {"start_s": 41.86, "end_s": 42.07, "speaker": "S1"},
+                {"start_s": 118.44, "end_s": 118.79, "speaker": "S2"},
+            ]}, 2.0, peak_rss_bytes=100)
+
+        def qwen(self, *, units, **kwargs):
+            texts = [
+                "language Chinese<asr_text>好，我們今天想聊一下你的工作。",
+                "language Chinese<asr_text>嗯，好啊，我做咗五年設計。",
+            ]
+            return StageOutcome("asr", "qwen3-asr-1.7b-8bit", {"units": [{
+                "unit_id": unit["unit_id"], "processed": True, "text": texts[index],
+            } for index, unit in enumerate(units)]}, 3.0, peak_rss_bytes=300,
+                                peak_mps_live_bytes=300)
+
+        def align(self, *, segments, **kwargs):
+            return StageOutcome("aligner", "qwen3-forcedaligner", {"segments": [{
+                "unit_id": segment["unit_id"], "words": [{
+                    "text": re.sub(r"\W", "", segment["text"]),
+                    "start": segment["start"], "end": segment["end"],
+                }],
+            } for segment in segments]}, 4.0, peak_rss_bytes=200,
+                                  peak_mps_live_bytes=200)
+
+    revisions = {
+        "qwen3-asr-1.7b-8bit": "a8379a2e2f9e313c9292cdf1af4055ab56d50d55",
+        "qwen3-forcedaligner": "0e1a68e91d815300c7c9754b2a7639378b23db15",
+        "speaker-diarization-coreml": "1ed7a662fdc7109e36d822db793ee6eebdaf8594",
+        "fluidaudio": "19600a485baa4998812e4654b70d2bab8f2c9949",
+    }
+    entries = {}
+    for identifier, revision in revisions.items():
+        target = tmp_path / identifier
+        target.mkdir()
+        materialized = {"path": str(target), "revision": revision}
+        if identifier == "fluidaudio":
+            materialized.update({"built": True, "product_runs": True})
+            product = target / ".build" / "release" / "fluidaudiocli"
+            product.parent.mkdir(parents=True)
+            product.write_text("#!/bin/sh\n", encoding="utf-8")
+            product.chmod(0o755)
+        entries[identifier] = {"state": "ready", "materialized": materialized}
+
+    request = resolve_request(
+        stack_id="qwen-1.7b", input_path=Path("meeting.m4a"),
+        wants="diarization,word_timestamps", language="Cantonese",
+    )
+    metadata = InputMetadata("meeting.m4a", 1794.2, "m4a", 44_100, 2)
+    registry = {
+        "environments": {"mlx": {"state": "ready"}, "swift": {"state": "ready"}},
+        "packages": entries,
+    }
+    actual = run(
+        request, metadata, registry=registry, transport=Transport()
+    ).payload
+    expected_plan = serialize_plan(build_plan(
+        request, metadata, provisioned_packages=set(entries),
+    ))
+    expected_plan.pop("sample_output")
+    assert actual["provenance"]["plan"] == expected_plan
+    documented = documented_block("audio transcribe run --input meeting.m4a \\")
+    # §1.2 publishes the resolved plan in full; §1.4 intentionally omits that repeated object.
+    documented["provenance"]["plan"] = expected_plan
+    assert_documented_shape(actual, documented, "audio transcribe run --stack qwen-1.7b")
+
+
+def test_qwen_incomplete_refusal_emits_the_shape_happy_path_publishes(tmp_path) -> None:
+    interpreter = tmp_path / "root" / "envs" / "mlx" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+    model = tmp_path / "qwen-model"
+    model.mkdir()
+
+    class PartialTransport:
+        def decode(self, source, target):
+            with wave.open(str(target), "wb") as handle:
+                handle.setnchannels(1)
+                handle.setsampwidth(2)
+                handle.setframerate(16_000)
+                handle.writeframes(b"\0\0" * (361 * 16_000))
+            return StageOutcome("decode", "ffmpeg", {}, 1.0, peak_rss_bytes=50)
+
+        def qwen(self, *, units, **kwargs):
+            return StageOutcome("asr", "qwen3-asr-0.6b-8bit", {"units": [{
+                "unit_id": item["unit_id"],
+                "processed": index == 0,
+                "text": "Hello." if index == 0 else "",
+            } for index, item in enumerate(units)]}, 2.0, returncode=4)
+
+    request = resolve_request(
+        stack_id="qwen-0.6b", input_path=tmp_path / "meeting.m4a", wants=(),
+    )
+    metadata = InputMetadata(str(request.input_path), 361.0, "m4a", 44_100, 2)
+    registry = {
+        "environments": {"mlx": {"state": "ready"}},
+        "packages": {"qwen3-asr-0.6b-8bit": {
+            "state": "ready",
+            "materialized": {
+                "path": str(model),
+                "revision": "89e96d92ba34aca20b3e29fb10cc284097d1219f",
+            },
+        }},
+    }
+    with pytest.raises(refusals.Refusal) as raised:
+        run(
+            request,
+            metadata,
+            registry=registry,
+            transport=PartialTransport(),
+            output=tmp_path / "meeting.timed.json",
+        )
+    documented = documented_block("A Qwen budget stop emits")
+    assert_documented_shape(
+        raised.value.payload,
+        documented,
+        "audio transcribe run incomplete refusal",
+    )

--- a/tests/test_spec_docs.py
+++ b/tests/test_spec_docs.py
@@ -200,7 +200,10 @@ def test_most_fixes_are_runnable_commands() -> None:
         for _, doc in json_blocks(path):
             if isinstance(doc, dict) and "code" in doc and not doc["fix"].startswith("audio "):
                 sentence_fixes.add(doc["code"])
-    assert sentence_fixes == {"capability_unsupported", "backend_failed"}, (
+    assert sentence_fixes == {
+        "capability_unsupported", "backend_failed", "stack_run_unavailable",
+        "output_is_canonical_input",
+    }, (
         f"unexpected sentence-only fixes: {sorted(sentence_fixes)}. Every other code has a "
         "configuration that works, so its fix must be copy-pasteable."
     )

--- a/tests/test_transcribe_adapters.py
+++ b/tests/test_transcribe_adapters.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from audio_cli.transcribe.adapters import (
+    normalize_aligned_words,
+    normalize_qwen_segments,
+    normalize_vad_regions,
+    reconcile_turns,
+    sentence_segments,
+    split_sentences,
+    strip_qwen_scaffold,
+)
+
+
+def test_qwen_no_hint_scaffold_is_stripped_and_not_replaced_with_a_default() -> None:
+    # This exact protocol prefix is recorded by run_qwen_verbatim_probe.py:553-558 for the
+    # no-hint private API path. Removing the adapter strip makes this assertion fail.
+    assert strip_qwen_scaffold("language English<asr_text>Hello.") == "Hello."
+    assert strip_qwen_scaffold("language Chinese<asr_text>你好。") == "你好。"
+    assert strip_qwen_scaffold("Hello without a scaffold.") == "Hello without a scaffold."
+
+    segments, missing = normalize_qwen_segments(
+        {"units": [{
+            "unit_id": "u0", "processed": True,
+            "text": "language English<asr_text>Hello.",
+        }]},
+        [{"unit_id": "u0", "start": 0.0, "end": 1.0}],
+    )
+    assert segments == [{
+        "unit_id": "u0", "start": 0.0, "end": 1.0, "text": "Hello.",
+    }]
+    assert missing == []
+
+
+def test_qwen_text_is_sentence_segmented_and_aligned_words_follow_punctuation() -> None:
+    assert split_sentences("Hello world. 你好！Value 1.5 is kept") == [
+        "Hello world.", "你好！", "Value 1.5 is kept",
+    ]
+    assert split_sentences("Wait... okay.") == ["Wait...", "okay."]
+    assert split_sentences("真的?!") == ["真的?!"]
+    assert split_sentences("...Hello.") == ["...Hello."]
+    assert split_sentences("……？！") == ["……？！"]
+    assert sentence_segments(
+        [{"unit_id": "u0", "text": "Hello, world. Next!", "speaker": "S1"}],
+        {"u0": [
+            {"text": "Hello", "start": 0.0, "end": 0.2},
+            {"text": "world", "start": 0.2, "end": 0.4},
+            {"text": "Next", "start": 0.5, "end": 0.7},
+        ]},
+    ) == [
+        {"unit_id": "u0", "text": "Hello, world.", "speaker": "S1", "words": [
+            {"text": "Hello", "start": 0.0, "end": 0.2},
+            {"text": "world", "start": 0.2, "end": 0.4},
+        ]},
+        {"unit_id": "u0", "text": "Next!", "speaker": "S1", "words": [
+            {"text": "Next", "start": 0.5, "end": 0.7},
+        ]},
+    ]
+    assert sentence_segments(
+        [{"unit_id": "u0", "text": "Hello."}],
+        {"u0": [{"text": "Goodbye", "start": 0.0, "end": 0.2}]},
+    ) == [{"unit_id": "u0", "text": "Hello."}]
+
+
+def test_diarizer_reconciles_exact_thresholds_and_drops_raw_embeddings() -> None:
+    raw = {"segments": [
+        {"startTimeSeconds": 0.0, "endTimeSeconds": 0.6, "speakerId": "S1",
+         "embedding": [0.0] * 256},
+        {"startTimeSeconds": 0.8, "endTimeSeconds": 1.4, "speakerId": "S1",
+         "embedding": [1.0] * 256},
+        {"startTimeSeconds": 1.2, "endTimeSeconds": 1.8, "speakerId": "S2",
+         "embedding": [2.0] * 256},
+        {"startTimeSeconds": 1.85, "endTimeSeconds": 2.0, "speakerId": "S3",
+         "embedding": [3.0] * 256},
+    ]}
+    plan = reconcile_turns(raw, duration_seconds=2.0)
+    assert plan.units == ({
+        "unit_id": "turn_0", "speaker": "S1", "start": 0.0, "end": 1.2,
+    },)
+    assert plan.overlaps == ({"start": 1.2, "end": 1.4},)
+    assert plan.short_turns == ({"start": 1.4, "end": 1.8},)
+    assert plan.raw_fragments == ({"start": 1.85, "end": 2.0},)
+    assert "embedding" not in repr(plan)
+
+
+def test_diarizer_accepts_exact_250ms_fragment_and_500ms_turn() -> None:
+    fragment_floor = reconcile_turns(
+        {"segments": [{"start_s": 0.0, "end_s": 0.25, "speaker": "S1"}]},
+        duration_seconds=0.25,
+    )
+    assert fragment_floor.raw_fragments == ()
+    assert fragment_floor.short_turns == ({"start": 0.0, "end": 0.25},)
+
+    turn_floor = reconcile_turns(
+        {"segments": [{"start_s": 0.0, "end_s": 0.5, "speaker": "S1"}]},
+        duration_seconds=0.5,
+    )
+    assert len(turn_floor.units) == 1
+    assert turn_floor.raw_fragments == ()
+
+
+def test_same_speaker_merge_accepts_300ms_gap_and_refuses_301ms() -> None:
+    at_floor = reconcile_turns(
+        {"segments": [
+            {"start_s": 0.0, "end_s": 0.3, "speaker": "S1"},
+            {"start_s": 0.6, "end_s": 0.9, "speaker": "S1"},
+        ]},
+        duration_seconds=0.9,
+    )
+    assert at_floor.units == ({
+        "unit_id": "turn_0", "speaker": "S1", "start": 0.0, "end": 0.9,
+    },)
+
+    over_floor = reconcile_turns(
+        {"segments": [
+            {"start_s": 0.0, "end_s": 0.3, "speaker": "S1"},
+            {"start_s": 0.601, "end_s": 0.901, "speaker": "S1"},
+        ]},
+        duration_seconds=0.901,
+    )
+    assert over_floor.units == ()
+    assert over_floor.short_turns == (
+        {"start": 0.0, "end": 0.3},
+        {"start": 0.601, "end": 0.901},
+    )
+
+
+def test_raw_fragment_inside_gap_blocks_merge_like_the_recorded_runner() -> None:
+    # run_turn_attributed_mlx_asr.py:330-355 merges only one pure `gap` span and its
+    # recorded note explicitly says never across a filtered-fragment abstention.
+    plan = reconcile_turns(
+        {"segments": [
+            {"start_s": 0.0, "end_s": 0.3, "speaker": "S1"},
+            {"start_s": 0.4, "end_s": 0.5, "speaker": "S2"},
+            {"start_s": 0.6, "end_s": 0.9, "speaker": "S1"},
+        ]},
+        duration_seconds=0.9,
+    )
+    assert plan.units == ()
+    assert plan.raw_fragments == ({"start": 0.4, "end": 0.5},)
+
+
+def test_discarded_fragment_does_not_split_a_kept_speaker_turn() -> None:
+    plan = reconcile_turns(
+        {"segments": [
+            {"start_s": 0.0, "end_s": 2.0, "speaker": "S1"},
+            {"start_s": 0.5, "end_s": 0.6, "speaker": "S2"},
+        ]},
+        duration_seconds=2.0,
+    )
+    assert plan.units == ({
+        "unit_id": "turn_0", "speaker": "S1", "start": 0.0, "end": 2.0,
+    },)
+    assert plan.short_turns == ()
+    assert plan.raw_fragments == ()
+
+
+def test_aligner_and_vad_normalizers_publish_only_owned_fields() -> None:
+    words = normalize_aligned_words(
+        {"segments": [{
+            "unit_id": "u0", "language": "Chinese",
+            "words": [{"text": "你", "start": 1.2, "end": 1.4, "score": 0.8}],
+        }]},
+        [{"unit_id": "u0"}],
+    )
+    assert words == {"u0": [{"text": "你", "start": 1.2, "end": 1.4}]}
+    rounded = normalize_aligned_words(
+        {"segments": [{
+            "unit_id": "u1",
+            "words": [{"text": "Hi", "start": 2.28, "end": 4.791}],
+        }]},
+        [{"unit_id": "u1", "start": 2.280125, "end": 4.790625}],
+    )
+    assert rounded == {"u1": [{
+        "text": "Hi", "start": 2.280125, "end": 4.790625,
+    }]}
+    assert normalize_vad_regions([{
+        "start": 0.1, "end": 0.9, "mean_probability": 0.8,
+    }]) == [{"start": 0.1, "end": 0.9}]
+    assert normalize_aligned_words(
+        {"segments": [{
+            "unit_id": "u0",
+            "words": [{"text": "bad", "start": -1.0, "end": 0.2}],
+        }]},
+        [{"unit_id": "u0"}],
+    ) == {}

--- a/tests/test_transcribe_cli.py
+++ b/tests/test_transcribe_cli.py
@@ -132,3 +132,152 @@ def test_globally_unsupported_capability_never_checks_provisioning(
             "labels a whole speech region"
         ),
     }
+
+
+def test_run_missing_package_is_bare_exit_three_after_probe_but_before_transport(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(cli, "probe_media", lambda path: probe())
+    monkeypatch.setattr(cli.transcribe_orchestrator, "load_registry", lambda: {
+        "packages": {}, "environments": {},
+    })
+
+    class ForbiddenTransport:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("exit 3 reached model transport")
+
+    monkeypatch.setattr(cli.transcribe_orchestrator, "StageTransport", ForbiddenTransport)
+    assert cli.main([
+        "transcribe", "run", "--input", "sample.wav", "--stack", "qwen-0.6b",
+    ]) == 3
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    error = json.loads(captured.err)
+    assert error == {
+        "code": "packages_not_provisioned",
+        "missing": [{
+            "package": "qwen3-asr-0.6b-8bit",
+            "kind": "weights",
+            "bytes": 1010773761,
+        }],
+        "total_known_download_bytes": 1010773761,
+        "unsized_packages": [],
+        "fix": "audio packages pull --stack qwen-0.6b",
+    }
+
+
+def test_run_resolves_stack_refusal_before_range_and_media(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        cli, "probe_media",
+        lambda path: (_ for _ in ()).throw(AssertionError("request refusal reached probe")),
+    )
+    assert cli.main([
+        "transcribe", "run", "--input", "sample.wav", "--range", "bad",
+    ]) == 2
+    assert json.loads(capsys.readouterr().err)["code"] == "stack_required"
+
+
+def test_run_malformed_range_is_bare_and_precedes_media(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        cli,
+        "probe_media",
+        lambda path: (_ for _ in ()).throw(AssertionError("range refusal reached probe")),
+    )
+    assert cli.main([
+        "transcribe", "run", "--input", "sample.wav", "--stack", "qwen-0.6b",
+        "--range", "not-a-range",
+    ]) == 2
+    error = json.loads(capsys.readouterr().err)
+    assert error["code"] == "range_invalid"
+    assert error["field"] == "--range"
+    assert error["provided"] == "not-a-range"
+    assert "error" not in error
+
+
+def test_run_refuses_existing_output_and_partial_before_media(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    source = tmp_path / "sample.wav"
+    source.write_bytes(b"source")
+    output = tmp_path / "result.json"
+    output.write_text("keep", encoding="utf-8")
+    monkeypatch.setattr(
+        cli, "probe_media",
+        lambda path: (_ for _ in ()).throw(AssertionError("collision reached probe")),
+    )
+    assert cli.main([
+        "transcribe", "run", "--input", str(source), "--stack", "qwen-0.6b",
+        "-o", str(output),
+    ]) == 2
+    error = json.loads(capsys.readouterr().err)
+    assert error["code"] == "output_exists"
+    assert error["existing"] == str(output)
+    assert error["fix"].endswith(f"-o {output} --force")
+    assert "error" not in error
+    assert output.read_text(encoding="utf-8") == "keep"
+
+    output.unlink()
+    partial = tmp_path / "result.partial.json"
+    partial.write_text("keep partial", encoding="utf-8")
+    assert cli.main([
+        "transcribe", "run", "--input", str(source), "--stack", "qwen-0.6b",
+        "-o", str(output),
+    ]) == 2
+    error = json.loads(capsys.readouterr().err)
+    assert error["code"] == "output_exists"
+    assert error["existing"] == str(partial)
+    assert error["fix"].endswith(f"-o {output} --force")
+    assert partial.read_text(encoding="utf-8") == "keep partial"
+
+
+def test_run_force_still_cannot_target_the_canonical_input(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    source = tmp_path / "sample.wav"
+    source.write_bytes(b"source")
+    monkeypatch.setattr(
+        cli, "probe_media",
+        lambda path: (_ for _ in ()).throw(AssertionError("source collision reached probe")),
+    )
+    assert cli.main([
+        "transcribe", "run", "--input", str(source), "--stack", "qwen-0.6b",
+        "-o", str(source), "--force",
+    ]) == 2
+    error = json.loads(capsys.readouterr().err)
+    assert error["code"] == "output_is_canonical_input"
+    assert error["resolved_target"] == str(source)
+    assert not error["fix"].startswith("audio ")
+    assert source.read_bytes() == b"source"
+
+
+def test_unimplemented_run_stack_refuses_before_media_or_provisioning(
+    monkeypatch, capsys
+) -> None:
+    def forbidden(*args, **kwargs):
+        raise AssertionError("unimplemented run reached external state")
+    monkeypatch.setattr(cli, "probe_media", forbidden)
+    monkeypatch.setattr(cli, "load_registry", forbidden)
+    assert cli.main([
+        "transcribe", "run", "--input", "sample.wav", "--stack", "firered",
+    ]) == 2
+    assert json.loads(capsys.readouterr().err) == {
+        "code": "stack_run_unavailable",
+        "stack": "firered",
+        "issue": 22,
+        "fix": (
+            "the firered run adapter is tracked in "
+            "https://github.com/fyang0507/audio-processing-cli/issues/22"
+        ),
+    }
+
+
+def test_unimplemented_run_stack_refuses_before_range_parsing(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        cli, "probe_media",
+        lambda path: (_ for _ in ()).throw(AssertionError("stack refusal reached probe")),
+    )
+    assert cli.main([
+        "transcribe", "run", "--input", "sample.wav", "--stack", "firered",
+        "--range", "not-a-range",
+    ]) == 2
+    assert json.loads(capsys.readouterr().err)["code"] == "stack_run_unavailable"

--- a/tests/test_transcribe_orchestrator.py
+++ b/tests/test_transcribe_orchestrator.py
@@ -1,0 +1,1029 @@
+from __future__ import annotations
+
+import inspect
+import json
+import wave
+from pathlib import Path
+
+import pytest
+
+from audio_cli.transcribe import orchestrator, refusals
+from audio_cli.transcribe.catalog import InputMetadata
+from audio_cli.transcribe.plan import serialize_plan
+from audio_cli.transcribe.planner import build_plan, resolve_request
+from audio_cli.transcribe.transport import StageOutcome
+from audio_cli.vad import SileroOnnxVad
+
+REVISION = "89e96d92ba34aca20b3e29fb10cc284097d1219f"
+ALIGNER_REVISION = "0e1a68e91d815300c7c9754b2a7639378b23db15"
+FLUID_REVISION = "19600a485baa4998812e4654b70d2bab8f2c9949"
+SPEAKER_REVISION = "1ed7a662fdc7109e36d822db793ee6eebdaf8594"
+
+
+@pytest.fixture(autouse=True)
+def provisioned_runtime_root(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "runtime"
+    monkeypatch.setenv("AUDIO_PROCESSING_MODEL_CACHE", str(root))
+    interpreter = root / "envs" / "mlx" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+
+
+def request(tmp_path: Path, *, wants=(), run_range=None):
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=wants,
+    )
+    metadata = InputMetadata(str(source), 361.0, "wav", 48_000, 2)
+    return resolved, metadata, run_range
+
+
+def registry(tmp_path: Path) -> dict:
+    model = tmp_path / "model"
+    model.mkdir(exist_ok=True)
+    return {"environments": {"mlx": {"state": "ready"}}, "packages": {
+        "qwen3-asr-0.6b-8bit": {
+        "state": "ready",
+        "materialized": {"path": str(model), "revision": REVISION},
+    }}}
+
+
+class FakeTransport:
+    def __init__(self, *, partial: bool = False) -> None:
+        self.partial = partial
+        self.units = []
+
+    def decode(self, source, target):
+        with wave.open(str(target), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(16_000)
+            handle.writeframes(b"\0\0" * (361 * 16_000))
+        return StageOutcome("decode", "ffmpeg", {}, 2.0, peak_rss_bytes=50)
+
+    def qwen(self, *, units, **kwargs):
+        self.units = units
+        raw = []
+        for index, item in enumerate(units):
+            raw.append({
+                "unit_id": item["unit_id"],
+                "processed": not self.partial or index == 0,
+                "text": "language English<asr_text>Hello.",
+            })
+        return StageOutcome(
+            "asr", "qwen3-asr-0.6b-8bit", {"units": raw}, 3.0,
+            returncode=4 if self.partial else 0,
+            peak_rss_bytes=100,
+        )
+
+
+class FullFakeTransport(FakeTransport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.diarizer_calls = 0
+        self.overlap = None
+
+    def decode(self, source, target):
+        with wave.open(str(target), "wb") as handle:
+            handle.setnchannels(1)
+            handle.setsampwidth(2)
+            handle.setframerate(16_000)
+            handle.writeframes(b"\0\0" * 32_000)
+        return StageOutcome("decode", "ffmpeg", {}, 1.0, peak_rss_bytes=50)
+
+    def diarize(self, *, overlap, **kwargs):
+        self.diarizer_calls += 1
+        self.overlap = overlap
+        return StageOutcome("diarizer", "fluidaudio", {"segments": [
+            {"startTimeSeconds": 0.0, "endTimeSeconds": 1.0, "speakerId": "S1",
+             "embedding": [0.0] * 256},
+            {"startTimeSeconds": 0.8, "endTimeSeconds": 1.8, "speakerId": "S2",
+             "embedding": [1.0] * 256},
+        ]}, 2.0, peak_rss_bytes=80)
+
+    def align(self, *, segments, **kwargs):
+        return StageOutcome("aligner", "qwen3-forcedaligner", {"segments": [{
+            "unit_id": item["unit_id"],
+            "words": [{"text": "Hello", "start": item["start"], "end": item["end"]}],
+        } for item in segments]}, 4.0, peak_rss_bytes=200, peak_mps_live_bytes=150)
+
+
+class FakeVad:
+    def detect(self, samples, rate, **config):
+        assert rate == 16_000
+        assert config["min_silence_ms"] == 300
+        return [{"start": 0.1, "end": 1.9, "mean_probability": 0.8}]
+
+
+def full_registry(tmp_path: Path) -> dict:
+    packages = {}
+    for identifier, revision in (
+        ("qwen3-asr-0.6b-8bit", REVISION),
+        ("qwen3-forcedaligner", ALIGNER_REVISION),
+        ("speaker-diarization-coreml", SPEAKER_REVISION),
+    ):
+        target = tmp_path / identifier
+        target.mkdir(exist_ok=True)
+        packages[identifier] = {
+            "state": "ready",
+            "materialized": {"path": str(target), "revision": revision},
+        }
+    fluid = tmp_path / "fluidaudio"
+    fluid.mkdir(exist_ok=True)
+    product = fluid / ".build" / "release" / "fluidaudiocli"
+    product.parent.mkdir(parents=True, exist_ok=True)
+    product.write_text("#!/bin/sh\n", encoding="utf-8")
+    product.chmod(0o755)
+    packages["fluidaudio"] = {
+        "state": "ready",
+        "materialized": {
+            "path": str(fluid), "revision": FLUID_REVISION,
+            "built": True, "product_runs": True,
+        },
+    }
+    return {
+        "environments": {"mlx": {"state": "ready"}, "swift": {"state": "ready"}},
+        "packages": packages,
+    }
+
+
+def test_qwen_floor_run_uses_fixed_units_and_never_publishes_container_bounds(tmp_path) -> None:
+    resolved, metadata, run_range = request(tmp_path)
+    fake = FakeTransport()
+    product = orchestrator.run(
+        resolved, metadata, registry=registry(tmp_path), transport=fake,
+        run_range=run_range,
+    )
+    assert [(item["start"], item["end"]) for item in fake.units] == [
+        (0.0, 180.0), (180.0, 360.0), (360.0, 361.0),
+    ]
+    assert product.payload["segments"] == [
+        {"segment_id": "seg_0", "text": "Hello."},
+        {"segment_id": "seg_1", "text": "Hello."},
+        {"segment_id": "seg_2", "text": "Hello."},
+    ]
+    assert product.payload["provenance"]["observed"]["peak_rss_bytes"] == 100
+    assert product.payload["provenance"]["observed"]["total_wall_seconds"] == 5.0
+
+
+def test_partial_qwen_run_writes_conforming_result_and_exact_resume_ledger(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    output = tmp_path / "requested.md"
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved, metadata, registry=registry(tmp_path),
+            transport=FakeTransport(partial=True), output=output,
+        )
+    assert raised.value.exit_code == 4
+    assert raised.value.payload["code"] == "run_incomplete"
+    partial = tmp_path / "requested.partial.json"
+    assert raised.value.payload["output"] == str(partial)
+    assert not output.exists()
+    payload = json.loads(partial.read_text(encoding="utf-8"))
+    assert payload["complete"] is False
+    assert payload["coverage"] == raised.value.payload["coverage"]
+    assert payload["coverage"]["covered_intervals"] == [[0.0, 180.0]]
+    assert payload["coverage"]["missing_intervals"] == [[180.0, 361.0]]
+    assert payload["coverage"]["scope_intervals"] == [[0.0, 361.0]]
+    assert "--range 180.0:" in raised.value.payload["fix"]
+
+
+def test_repeated_incomplete_resumes_never_overwrite_an_earlier_partial(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    with pytest.raises(refusals.Refusal) as first:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=registry(tmp_path),
+            transport=FakeTransport(partial=True),
+            output=tmp_path / "meeting.timed.json",
+        )
+    first_partial = Path(first.value.payload["output"])
+    first_bytes = first_partial.read_bytes()
+    assert first_partial.name == "meeting.timed.partial.json"
+
+    with pytest.raises(refusals.Refusal) as second:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=registry(tmp_path),
+            transport=FakeTransport(partial=True),
+            output=tmp_path / "meeting.timed.rest.json",
+            run_range=orchestrator.parse_range("180:"),
+        )
+    second_partial = Path(second.value.payload["output"])
+    assert second_partial.name == "meeting.timed.rest.partial.json"
+    assert first_partial.read_bytes() == first_bytes
+    assert first_partial.is_file() and second_partial.is_file()
+
+
+def test_repeated_implicit_partial_outputs_choose_unused_siblings(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    with pytest.raises(refusals.Refusal) as first:
+        orchestrator.run(
+            resolved, metadata, registry=registry(tmp_path),
+            transport=FakeTransport(partial=True),
+        )
+    first_partial = Path(first.value.payload["output"])
+    first_bytes = first_partial.read_bytes()
+
+    with pytest.raises(refusals.Refusal) as second:
+        orchestrator.run(
+            resolved, metadata, registry=registry(tmp_path),
+            transport=FakeTransport(partial=True),
+        )
+    second_partial = Path(second.value.payload["output"])
+    assert first_partial.name == "source.partial.json"
+    assert second_partial.name == "source.partial.2.json"
+    assert first_partial.read_bytes() == first_bytes
+    assert second_partial.is_file()
+
+
+def test_bounded_partial_resume_preserves_the_requested_end(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=registry(tmp_path),
+            transport=FakeTransport(partial=True),
+            output=tmp_path / "bounded.json",
+            run_range=orchestrator.parse_range("100:300"),
+        )
+    assert "--range 180.0:300.0" in raised.value.payload["fix"]
+
+
+def test_zero_completed_units_write_a_partial_without_a_replaying_fix(tmp_path) -> None:
+    class ExhaustedTransport(FakeTransport):
+        def qwen(self, *, units, **kwargs):
+            self.units = units
+            return StageOutcome("asr", "qwen3-asr-0.6b-8bit", {"units": [{
+                "unit_id": item["unit_id"], "processed": False, "text": "",
+            } for item in units]}, 3.0, returncode=4)
+
+    resolved, metadata, _ = request(tmp_path)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=registry(tmp_path),
+            transport=ExhaustedTransport(),
+        )
+    assert raised.value.exit_code == 4
+    assert raised.value.payload["code"] == "run_incomplete"
+    coverage = raised.value.payload["coverage"]
+    assert coverage["covered_intervals"] == []
+    assert coverage["missing_intervals"] == [[0.0, 361.0]]
+    assert coverage["covered_fraction"] == 0.0
+    assert coverage["units_completed"] == 0
+    assert raised.value.payload["fix"] == (
+        "no processing unit completed; --range would repeat the same deterministic work, "
+        "so inspect the first unit or backend budget before retrying"
+    )
+    partial = json.loads(
+        Path(raised.value.payload["output"]).read_text(encoding="utf-8")
+    )
+    assert partial["complete"] is False
+    assert partial["segments"] == []
+
+
+def test_zero_prefix_partial_does_not_claim_diarizer_abstained(tmp_path) -> None:
+    class ExhaustedDiarizedTransport(FullFakeTransport):
+        def qwen(self, *, units, **kwargs):
+            return StageOutcome("asr", "qwen3-asr-0.6b-8bit", {"units": [{
+                "unit_id": item["unit_id"], "processed": False, "text": "",
+            } for item in units]}, 1.0, returncode=4)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=full_registry(tmp_path),
+            transport=ExhaustedDiarizedTransport(),
+        )
+    partial = json.loads(
+        Path(raised.value.payload["output"]).read_text(encoding="utf-8")
+    )
+    assert partial["provenance"]["outcomes"]["diarization"] == "produced"
+
+
+def test_preflight_refuses_missing_package_before_transport_exists(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(resolved, metadata, registry={"packages": {}})
+    assert raised.value.exit_code == 3
+    assert raised.value.payload["missing"] == [{
+        "package": "qwen3-asr-0.6b-8bit",
+        "kind": "weights",
+        "bytes": 1010773761,
+    }]
+
+
+def test_preflight_refuses_missing_runtime_before_decode(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    document = registry(tmp_path)
+    document["environments"]["mlx"]["state"] = "absent"
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(resolved, metadata, registry=document)
+    assert raised.value.exit_code == 3
+    assert raised.value.payload["failed"] == [{
+        "package": "qwen3-asr-0.6b-8bit",
+        "check": "environment_mlx_ready",
+        "expected": "ready",
+        "actual": "absent",
+    }]
+
+
+def test_preflight_refuses_missing_swift_product_before_decode(tmp_path) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    document = full_registry(tmp_path)
+    product = tmp_path / "fluidaudio" / ".build" / "release" / "fluidaudiocli"
+    product.unlink()
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(resolved, metadata, registry=document)
+    assert raised.value.exit_code == 3
+    assert any(
+        item["check"] == "built_product_executable"
+        for item in raised.value.payload["failed"]
+    )
+
+
+def test_vad_plan_config_is_exactly_the_detector_keyword_surface(tmp_path) -> None:
+    source = tmp_path / "source.wav"
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("vad",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 16_000, 1)
+    plan = build_plan(
+        resolved, metadata, provisioned_packages={"qwen3-asr-0.6b-8bit"},
+    )
+    parameters = inspect.signature(SileroOnnxVad.detect).parameters
+    keyword_only = {
+        name for name, parameter in parameters.items()
+        if parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    }
+    assert set(plan.roles["vad"]["config"]) == keyword_only
+
+
+def test_qwen_add_ons_share_full_timeline_and_capability_gated_output(
+    tmp_path, monkeypatch
+) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b",
+        input_path=source,
+        wants=("diarization", "overlapped_speech", "word_timestamps", "vad"),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    fake = FullFakeTransport()
+    monkeypatch.setattr(orchestrator, "_self_peak_rss", lambda: 120)
+    product = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=fake,
+        vad_detector=FakeVad(),
+        run_range=orchestrator.parse_range("0.5:"),
+    )
+    assert fake.diarizer_calls == 1
+    assert fake.overlap is True
+    assert fake.units == [
+        {"unit_id": "turn_0", "speaker": "S1", "start": 0.0, "end": 0.8},
+        {"unit_id": "turn_1", "speaker": "S2", "start": 1.0, "end": 1.8},
+    ]
+    assert product.payload["turns"] == [
+        {"turn_id": "turn_0", "speaker": "S1", "start": 0.0, "end": 0.8},
+        {"turn_id": "turn_1", "speaker": "S2", "start": 1.0, "end": 1.8},
+    ]
+    assert product.payload["overlapped_speech"] == [
+        {"overlap_id": "overlap_0", "start": 0.8, "end": 1.0},
+    ]
+    assert product.payload["abstentions"] == [{
+        "abstention_id": "ab_0", "reason": "overlap", "start": 0.8, "end": 1.0,
+    }]
+    assert product.payload["vad_regions"] == [{"start": 0.1, "end": 1.9}]
+    assert product.payload["provenance"]["plan"]["execution"]["range"] == {
+        "requested": [0.5, 2.0],
+        "selected_unit_scope": [0.0, 1.8],
+    }
+    assert all("start" not in item and "end" not in item for item in product.payload["segments"])
+    assert product.payload["segments"][0]["words"] == [{
+        "word_id": "w_0", "text": "Hello", "start": 0.0, "end": 0.8,
+    }]
+    observed = product.payload["provenance"]["observed"]
+    assert observed["peak_rss_bytes"] == 200
+    assert observed["peak_rss_bytes_by_stage"] == {
+        "decode": 50, "diarizer": 80, "vad": 120, "asr": 100, "aligner": 200,
+    }
+    assert observed["peak_mps_live_bytes"] == 150
+
+
+def test_preflight_defends_against_legacy_ready_but_unrunnable_registry(tmp_path) -> None:
+    """Older registries may claim ready despite product_runs=false; current pull cannot."""
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=tmp_path / "source.wav", wants=("diarization",),
+    )
+    metadata = InputMetadata("source.wav", 2.0, "wav", 16_000, 1)
+    document = full_registry(tmp_path)
+    document["packages"]["fluidaudio"]["materialized"]["built"] = False
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(resolved, metadata, registry=document)
+    assert raised.value.payload["code"] == "package_integrity_failed"
+    assert raised.value.payload["failed"][0]["check"] == "built"
+
+    document["packages"]["fluidaudio"]["materialized"]["built"] = True
+    document["packages"]["fluidaudio"]["materialized"]["product_runs"] = False
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(resolved, metadata, registry=document)
+    assert raised.value.payload["code"] == "package_build_unusable"
+
+
+def test_nonintersecting_range_refuses_after_decode_but_before_model(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+
+    class DecodeOnly(FakeTransport):
+        decode_calls = 0
+
+        def decode(self, source, target):
+            self.decode_calls += 1
+            return super().decode(source, target)
+
+        def qwen(self, **kwargs):
+            raise AssertionError("range validation reached model transport")
+
+    transport = DecodeOnly()
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=registry(tmp_path),
+            transport=transport,
+            run_range=orchestrator.parse_range("400:"),
+        )
+    assert transport.decode_calls == 1
+    assert raised.value.exit_code == 2
+    assert raised.value.payload["code"] == "range_invalid"
+    assert raised.value.payload["provided"] == "400:"
+
+
+def test_open_range_end_resolves_against_canonical_not_shorter_probe(tmp_path) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(stack_id="qwen-0.6b", input_path=source, wants=())
+    metadata = InputMetadata(str(source), 1.0, "wav", 48_000, 2)
+    transport = FullFakeTransport()
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=registry(tmp_path),
+        transport=transport,
+        run_range=orchestrator.parse_range("0.5:"),
+    ).payload
+    assert transport.units == [{"unit_id": "unit_0", "start": 0.0, "end": 2.0}]
+    assert payload["provenance"]["plan"]["execution"]["range"]["requested"] == [
+        0.5, 2.0,
+    ]
+
+
+def test_fixed_units_match_the_catalog_rule_even_for_a_subsecond_tail(tmp_path) -> None:
+    resolved, _, _ = request(tmp_path)
+    assert orchestrator._fixed_units(360.0000625, resolved) == [
+        {"unit_id": "unit_0", "start": 0.0, "end": 180.0},
+        {"unit_id": "unit_1", "start": 180.0, "end": 360.0},
+        {"unit_id": "unit_2", "start": 360.0, "end": 360.000063},
+    ]
+
+
+class NoncontiguousTransport(FullFakeTransport):
+    def __init__(self, *, partial: bool) -> None:
+        super().__init__()
+        self.partial = partial
+
+    def diarize(self, **kwargs):
+        return StageOutcome("diarizer", "fluidaudio", {"segments": [
+            {"startTimeSeconds": 0.0, "endTimeSeconds": 0.6, "speakerId": "S1"},
+            {"startTimeSeconds": 0.6, "endTimeSeconds": 1.3, "speakerId": "S2"},
+            {"startTimeSeconds": 1.35, "endTimeSeconds": 1.45, "speakerId": "S4"},
+            {"startTimeSeconds": 1.5, "endTimeSeconds": 2.0, "speakerId": "S3"},
+        ]}, 1.0)
+
+    def qwen(self, *, units, **kwargs):
+        self.units = list(units)
+        return StageOutcome("asr", "qwen3-asr-0.6b-8bit", {"units": [
+            {
+                "unit_id": item["unit_id"],
+                "processed": not self.partial or item["unit_id"] != "turn_1",
+                "text": f"Text {item['unit_id']}.",
+            }
+            for item in units
+        ]}, 1.0, returncode=4 if self.partial else 0)
+
+
+def test_noncontiguous_partial_resume_reuses_whole_turn_bounds_and_labels(tmp_path) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    first_transport = NoncontiguousTransport(partial=True)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=full_registry(tmp_path),
+            transport=first_transport,
+        )
+    partial = json.loads(
+        Path(raised.value.payload["output"]).read_text(encoding="utf-8")
+    )
+    assert partial["coverage"]["covered_intervals"] == [[0.0, 0.6]]
+    assert partial["coverage"]["missing_intervals"] == [[0.6, 2.0]]
+    assert partial["turns"] == [
+        {"turn_id": "turn_0", "speaker": "S1", "start": 0.0, "end": 0.6},
+    ]
+    assert partial["abstentions"] == []
+
+    resume_transport = NoncontiguousTransport(partial=False)
+    resumed = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=resume_transport,
+        run_range=orchestrator.parse_range("0.6:"),
+    ).payload
+    assert resumed["turns"] == [
+        {"turn_id": "turn_1", "speaker": "S2", "start": 0.6, "end": 1.3},
+        {"turn_id": "turn_2", "speaker": "S3", "start": 1.5, "end": 2.0},
+    ]
+    assert resumed["abstentions"] == [{
+        "abstention_id": "ab_0",
+        "reason": "raw_fragment",
+        "start": 1.35,
+        "end": 1.45,
+    }]
+    assert resumed["provenance"]["plan"]["execution"]["range"] == {
+        "requested": [0.6, 2.0],
+        "selected_unit_scope": [0.6, 2.0],
+    }
+
+
+def test_open_resume_owns_auxiliary_evidence_after_the_last_selected_turn(tmp_path) -> None:
+    class TailEvidenceTransport(NoncontiguousTransport):
+        def decode(self, source, target):
+            with wave.open(str(target), "wb") as handle:
+                handle.setnchannels(1)
+                handle.setsampwidth(2)
+                handle.setframerate(16_000)
+                handle.writeframes(b"\0\0" * (3 * 16_000))
+            return StageOutcome("decode", "ffmpeg", {}, 1.0)
+
+        def diarize(self, **kwargs):
+            base = super().diarize(**kwargs).payload["segments"]
+            return StageOutcome("diarizer", "fluidaudio", {"segments": [
+                *base,
+                {"startTimeSeconds": 2.5, "endTimeSeconds": 2.6, "speakerId": "S5"},
+            ]}, 1.0)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    payload = orchestrator.run(
+        resolved,
+        InputMetadata(str(source), 3.0, "wav", 48_000, 2),
+        registry=full_registry(tmp_path),
+        transport=TailEvidenceTransport(partial=False),
+        run_range=orchestrator.parse_range("0.6:"),
+    ).payload
+    assert payload["abstentions"][-1] == {
+        "abstention_id": "ab_1",
+        "reason": "raw_fragment",
+        "start": 2.5,
+        "end": 2.6,
+    }
+
+
+def test_incomplete_hand_range_owns_evidence_before_its_first_selected_turn(tmp_path) -> None:
+    class GapExhaustedTransport(NoncontiguousTransport):
+        def diarize(self, **kwargs):
+            return StageOutcome("diarizer", "fluidaudio", {"segments": [
+                {"startTimeSeconds": 0.0, "endTimeSeconds": 1.3, "speakerId": "S1"},
+                {"startTimeSeconds": 1.42, "endTimeSeconds": 1.45, "speakerId": "S4"},
+                {"startTimeSeconds": 1.5, "endTimeSeconds": 2.0, "speakerId": "S2"},
+            ]}, 1.0)
+
+        def qwen(self, *, units, **kwargs):
+            self.units = list(units)
+            return StageOutcome("asr", "qwen3-asr-0.6b-8bit", {"units": [{
+                "unit_id": item["unit_id"], "processed": False, "text": "",
+            } for item in units]}, 1.0, returncode=4)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    transport = GapExhaustedTransport(partial=True)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved,
+            InputMetadata(str(source), 2.0, "wav", 48_000, 2),
+            registry=full_registry(tmp_path),
+            transport=transport,
+            run_range=orchestrator.parse_range("1.4:"),
+        )
+    partial = json.loads(
+        Path(raised.value.payload["output"]).read_text(encoding="utf-8")
+    )
+    assert transport.units == [{
+        "unit_id": "turn_1", "speaker": "S2", "start": 1.5, "end": 2.0,
+    }]
+    assert partial["coverage"]["scope_intervals"] == [[1.5, 2.0]]
+    assert partial["abstentions"] == [{
+        "abstention_id": "ab_0",
+        "reason": "raw_fragment",
+        "start": 1.42,
+        "end": 1.45,
+    }]
+
+
+def test_run_refuses_existing_outputs_before_decode_and_force_is_explicit(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    output = tmp_path / "result.json"
+    output.write_text("keep", encoding="utf-8")
+    transport = FakeTransport()
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved, metadata, registry=registry(tmp_path), transport=transport,
+            output=output,
+        )
+    assert raised.value.payload["code"] == "output_exists"
+    assert raised.value.payload["fix"].endswith(f"-o {output} --force")
+    assert transport.units == []
+    assert output.read_text(encoding="utf-8") == "keep"
+
+    payload = orchestrator.run(
+        resolved, metadata, registry=registry(tmp_path), transport=FakeTransport(),
+        output=output, force=True,
+    ).payload
+    assert json.loads(output.read_text(encoding="utf-8")) == payload
+
+
+def test_run_never_allows_output_to_resolve_to_canonical_input(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved, metadata, registry=registry(tmp_path), transport=FakeTransport(),
+            output=resolved.input_path, force=True,
+        )
+    assert raised.value.payload["code"] == "output_is_canonical_input"
+    assert resolved.input_path.read_bytes() == b"source"
+
+    derived_source = tmp_path / "meeting.partial.json"
+    derived_source.write_bytes(b"canonical")
+    derived_request = resolve_request(
+        stack_id="qwen-0.6b", input_path=derived_source, wants=(),
+    )
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            derived_request,
+            InputMetadata(str(derived_source), 361.0, "json", 48_000, 2),
+            registry=registry(tmp_path),
+            transport=FakeTransport(partial=True),
+            output=tmp_path / "meeting.json",
+            force=True,
+        )
+    assert raised.value.payload["code"] == "output_is_canonical_input"
+    assert raised.value.payload["resolved_target"] == str(derived_source)
+    assert derived_source.read_bytes() == b"canonical"
+
+
+def test_diarizer_exclusions_survive_without_requesting_diarization(tmp_path) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("overlapped_speech",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=NoncontiguousTransport(partial=False),
+    ).payload
+    assert "turns" not in payload
+    assert payload["abstentions"] == [{
+        "abstention_id": "ab_0",
+        "reason": "raw_fragment",
+        "start": 1.35,
+        "end": 1.45,
+    }]
+
+
+def test_overlap_abstention_survives_without_optional_overlap_array(tmp_path) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=FullFakeTransport(),
+    ).payload
+    assert "overlapped_speech" not in payload
+    assert payload["abstentions"] == [{
+        "abstention_id": "ab_0", "reason": "overlap", "start": 0.8, "end": 1.0,
+    }]
+
+
+def test_backend_failure_fix_does_not_promise_an_unrelated_command(tmp_path) -> None:
+    class BrokenTransport(FakeTransport):
+        def qwen(self, **kwargs):
+            from audio_cli.transcribe.transport import StageFailure
+
+            raise StageFailure("asr", "qwen3-asr-0.6b-8bit", "out of memory")
+
+    resolved, metadata, _ = request(tmp_path)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved, metadata, registry=registry(tmp_path), transport=BrokenTransport(),
+        )
+    assert raised.value.exit_code == 1
+    assert raised.value.payload["role"] == "asr"
+    assert raised.value.payload["backend"] == "qwen3-asr-0.6b-8bit"
+    assert not raised.value.payload["fix"].startswith("audio ")
+
+
+def test_backend_derived_result_error_is_one_json_refusal(tmp_path) -> None:
+    class NonLabelTransport(FullFakeTransport):
+        def diarize(self, **kwargs):
+            return StageOutcome("diarizer", "fluidaudio", {"segments": [{
+                "startTimeSeconds": 0.0,
+                "endTimeSeconds": 1.0,
+                "speakerId": "N/A",
+            }]}, 1.0)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    with pytest.raises(refusals.Refusal) as raised:
+        orchestrator.run(
+            resolved,
+            metadata,
+            registry=full_registry(tmp_path),
+            transport=NonLabelTransport(),
+        )
+    assert raised.value.exit_code == 1
+    assert raised.value.payload["code"] == "backend_failed"
+    assert "must be absent" in raised.value.payload["detail"]
+
+
+def test_abstentions_are_reidentified_in_source_order(tmp_path) -> None:
+    class MixedEvidenceTransport(FullFakeTransport):
+        def diarize(self, **kwargs):
+            return StageOutcome("diarizer", "fluidaudio", {"segments": [
+                {"startTimeSeconds": 0.0, "endTimeSeconds": 0.8, "speakerId": "S1"},
+                {"startTimeSeconds": 0.4, "endTimeSeconds": 1.0, "speakerId": "S2"},
+                {"startTimeSeconds": 1.2, "endTimeSeconds": 1.3, "speakerId": "S3"},
+                {"startTimeSeconds": 1.4, "endTimeSeconds": 2.0, "speakerId": "S4"},
+            ]}, 1.0)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b",
+        input_path=source,
+        wants=("diarization", "overlapped_speech"),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=MixedEvidenceTransport(),
+    ).payload
+    starts = [item["start"] for item in payload["abstentions"]]
+    assert starts == sorted(starts)
+    assert [item["abstention_id"] for item in payload["abstentions"]] == [
+        f"ab_{index}" for index in range(len(starts))
+    ]
+
+
+def test_empty_transcript_keeps_diarizer_abstention_evidence(tmp_path) -> None:
+    class RawOnlyTransport(FullFakeTransport):
+        def diarize(self, **kwargs):
+            return StageOutcome("diarizer", "fluidaudio", {"segments": [{
+                "startTimeSeconds": 0.2,
+                "endTimeSeconds": 0.3,
+                "speakerId": "S1",
+            }]}, 1.0)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("diarization",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=RawOnlyTransport(),
+    ).payload
+    assert payload["complete"] is True
+    assert payload["segments"] == []
+    assert payload["turns"] == []
+    assert payload["abstentions"] == [{
+        "abstention_id": "ab_0",
+        "reason": "raw_fragment",
+        "start": 0.2,
+        "end": 0.3,
+    }]
+    assert payload["provenance"]["outcomes"]["diarization"] == "produced"
+
+
+def test_alignment_abstention_is_observable_and_does_not_invent_words(tmp_path) -> None:
+    class AbstainingAligner(FullFakeTransport):
+        def align(self, *, segments, **kwargs):
+            return StageOutcome("aligner", "qwen3-forcedaligner", {"segments": [{
+                "unit_id": item["unit_id"], "words": None,
+            } for item in segments]}, 1.0)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("word_timestamps",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=AbstainingAligner(),
+    ).payload
+    assert all("words" not in item for item in payload["segments"])
+    assert payload["provenance"]["outcomes"]["word_timestamps"] == "abstained"
+    assert payload["provenance"]["observed"]["segments_without_words"] == 1
+
+
+def test_punctuation_only_alignment_with_empty_words_is_produced_not_abstained(
+    tmp_path,
+) -> None:
+    class PunctuationTransport(FakeTransport):
+        def qwen(self, *, units, **kwargs):
+            return StageOutcome("asr", "qwen3-asr-0.6b-8bit", {"units": [{
+                "unit_id": item["unit_id"], "processed": True, "text": "……？！",
+            } for item in units]}, 1.0)
+
+        def align(self, *, segments, **kwargs):
+            return StageOutcome("aligner", "qwen3-forcedaligner", {"segments": [{
+                "unit_id": item["unit_id"], "words": [],
+            } for item in segments]}, 1.0)
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("word_timestamps",),
+    )
+    payload = orchestrator.run(
+        resolved,
+        InputMetadata(str(source), 361.0, "wav", 48_000, 2),
+        registry=full_registry(tmp_path),
+        transport=PunctuationTransport(),
+    ).payload
+    assert all(item["words"] == [] for item in payload["segments"])
+    assert payload["provenance"]["outcomes"]["word_timestamps"] == "produced"
+    assert payload["provenance"]["observed"]["segments_without_words"] == 0
+
+
+def test_whole_aligner_failure_salvages_complete_asr_as_abstained(tmp_path) -> None:
+    class FailingAligner(FullFakeTransport):
+        def align(self, **kwargs):
+            from audio_cli.transcribe.transport import StageFailure
+
+            raise StageFailure("aligner", "qwen3-forcedaligner", "out of memory")
+
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=("word_timestamps",),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=FailingAligner(),
+    ).payload
+    assert payload["complete"] is True
+    assert payload["segments"] == [{"segment_id": "seg_0", "text": "Hello."}]
+    assert payload["provenance"]["outcomes"]["word_timestamps"] == "abstained"
+
+
+def test_canonical_wav_header_owns_duration_and_fixed_unit_bounds(tmp_path) -> None:
+    resolved, metadata, _ = request(tmp_path)
+    metadata = InputMetadata(metadata.source["path"], 999.0, "wav", 48_000, 2)
+    transport = FullFakeTransport()
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=registry(tmp_path),
+        transport=transport,
+    ).payload
+    assert payload["source"] == {
+        "path": str(resolved.input_path),
+        "duration_seconds": 2.0,
+        "timebase": "seconds",
+    }
+    assert transport.units == [{"unit_id": "unit_0", "start": 0.0, "end": 2.0}]
+
+
+def test_range_filters_auxiliary_observations_to_selected_processing_scope(tmp_path) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b",
+        input_path=source,
+        wants=("diarization", "overlapped_speech", "vad"),
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    payload = orchestrator.run(
+        resolved,
+        metadata,
+        registry=full_registry(tmp_path),
+        transport=FullFakeTransport(),
+        vad_detector=FakeVad(),
+        run_range=orchestrator.parse_range("1.2:1.5"),
+    ).payload
+    assert payload["turns"] == [{
+        "turn_id": "turn_1", "speaker": "S2", "start": 1.0, "end": 1.8,
+    }]
+    assert payload["overlapped_speech"] == []
+    assert payload["vad_regions"] == []
+    assert payload["provenance"]["plan"]["execution"]["range"] == {
+        "requested": [1.2, 1.5], "selected_unit_scope": [1.0, 1.8],
+    }
+
+
+@pytest.mark.parametrize("wants", [
+    (),
+    ("languages",),
+    ("verbatim",),
+    ("diarization",),
+    ("overlapped_speech",),
+    ("vad",),
+    ("word_timestamps",),
+    ("languages", "verbatim", "diarization", "overlapped_speech", "vad",
+     "word_timestamps"),
+])
+def test_real_qwen_result_shape_matches_its_plan_sample_over_derivation_cells(
+    tmp_path, wants
+) -> None:
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"source")
+    resolved = resolve_request(
+        stack_id="qwen-0.6b", input_path=source, wants=wants,
+    )
+    metadata = InputMetadata(str(source), 2.0, "wav", 48_000, 2)
+    document = full_registry(tmp_path)
+    ready = set(document["packages"])
+    sample = serialize_plan(build_plan(
+        resolved, metadata, provisioned_packages=ready,
+    ))["sample_output"]
+    actual = orchestrator.run(
+        resolved, metadata, registry=document, transport=FullFakeTransport(),
+        vad_detector=FakeVad(),
+    ).payload
+
+    assert set(actual) == set(sample) - {"sample", "note"}
+    assert set(actual["provenance"]) == set(sample["provenance"])
+    assert set(actual["segments"][0]) == set(sample["segments"][0])
+    assert set(actual["provenance"]["outcomes"]) == set(wants)
+    for capability, field in {
+        "diarization": "turns",
+        "overlapped_speech": "overlapped_speech",
+        "vad": "vad_regions",
+    }.items():
+        assert (field in actual) is (capability in wants)

--- a/tests/test_transcribe_refusals.py
+++ b/tests/test_transcribe_refusals.py
@@ -143,6 +143,12 @@ EXPECTED_KEYS = {
     "pin_conflicts_with_native_capability": {
         "code", "field", "provided", "allowed", "capability", "fix",
     },
+    "range_invalid": {"code", "field", "provided", "reason", "fix"},
+    "stack_run_unavailable": {"code", "stack", "issue", "fix"},
+    "output_exists": {"code", "field", "provided", "existing", "fix"},
+    "output_is_canonical_input": {
+        "code", "field", "provided", "resolved_target", "fix",
+    },
     "timing_required_for_format": {
         "code", "field", "provided", "requires_capability", "found", "note", "fix",
     },
@@ -162,6 +168,7 @@ def all_refusal_examples() -> list[refusals.Refusal]:
     qwen = stacks.get_stack("qwen-1.7b")
     vibe = stacks.get_stack("vibevoice")
     coverage = {
+        "scope_intervals": [[0.0, 2.0]],
         "covered_through_seconds": 1.0,
         "covered_fraction": 0.5,
         "covered_intervals": [[0.0, 1.0]],
@@ -193,11 +200,23 @@ def all_refusal_examples() -> list[refusals.Refusal]:
             vibe, "demo.mp4", "--diarizer", "fluidaudio", "diarization",
             ("diarization",),
         ),
+        refusals.range_invalid(
+            "meeting.m4a", "qwen-1.7b", ("diarization",), "bad",
+            "--range must be START: or START:END",
+        ),
+        refusals.stack_run_unavailable("firered", 22),
+        refusals.output_exists(
+            "meeting.m4a", "qwen-1.7b", ("diarization",),
+            "meeting.json", "meeting.json",
+        ),
+        refusals.output_is_canonical_input("meeting.m4a", "meeting.m4a"),
         refusals.timing_required_for_format(
             "meeting.json", "srt", (), "qwen-1.7b", ("verbatim",)
         ),
         refusals.packages_not_provisioned(
-            "qwen-1.7b", ("qwen3-asr-1.7b-8bit",), 123, ()
+            "qwen-1.7b", ({
+                "package": "qwen3-asr-1.7b-8bit", "kind": "weights", "bytes": 123,
+            },), 123, ()
         ),
         refusals.package_integrity_failed(({
             "package": "qwen3-forcedaligner", "check": "weight_digest",
@@ -214,7 +233,7 @@ def all_refusal_examples() -> list[refusals.Refusal]:
 
 def test_every_current_contract_refusal_has_one_fixed_shape_builder() -> None:
     examples = all_refusal_examples()
-    assert len(examples) == 14
+    assert len(examples) == 18
     assert {item.payload["code"] for item in examples} == set(EXPECTED_KEYS)
     for item in examples:
         assert set(item.payload) == EXPECTED_KEYS[item.payload["code"]]

--- a/tests/test_transcribe_result.py
+++ b/tests/test_transcribe_result.py
@@ -134,6 +134,7 @@ def test_languages_and_verbatim_add_no_result_key_and_cannot_abstain() -> None:
 
 def test_complete_and_coverage_are_bidirectional() -> None:
     coverage = {
+        "scope_intervals": [[0.0, 10.0]],
         "covered_through_seconds": 4.0,
         "covered_fraction": 0.4,
         "covered_intervals": [[0.0, 4.0]],
@@ -201,6 +202,25 @@ def test_real_attribution_and_lid_values_are_not_null_placeholders() -> None:
         ))
 
 
+def test_timed_output_cannot_leave_the_source_duration() -> None:
+    with pytest.raises(ResultError, match="source duration"):
+        serialize_result(base_result(
+            segments=[{
+                "segment_id": "seg_0",
+                "text": "Hello.",
+                "words": [{
+                    "word_id": "w_0", "text": "Hello", "start": 9.0, "end": 11.0,
+                }],
+            }],
+            requested_capabilities=frozenset({"word_timestamps"}),
+            provenance={
+                "stack": "qwen-1.7b",
+                "outcomes": {"word_timestamps": "produced"},
+                "observed": {},
+                "plan": {},
+            },
+        ))
+
 def test_overlap_id_is_a_non_empty_document_scoped_id() -> None:
     requested = frozenset({"overlapped_speech"})
     provenance = {
@@ -245,11 +265,11 @@ def test_abstention_reason_is_the_closed_recorded_enum() -> None:
 
 
 @pytest.mark.parametrize("reason", sorted(ABSTENTION_REASONS))
-def test_abstention_requires_the_capability_that_can_produce_it(reason: str) -> None:
-    with pytest.raises(ResultError, match="requires"):
-        serialize_result(base_result(abstentions=[{
-            "abstention_id": "ab_0", "reason": reason, "start": 0.0, "end": 0.2,
-        }]))
+def test_abstention_floor_is_not_gated_by_optional_capabilities(reason: str) -> None:
+    emitted = serialize_result(base_result(abstentions=[{
+        "abstention_id": "ab_0", "reason": reason, "start": 0.0, "end": 0.2,
+    }]))
+    assert emitted["abstentions"][0]["reason"] == reason
 
 
 def test_unknown_capability_and_model_specific_keys_are_rejected() -> None:
@@ -330,6 +350,7 @@ def test_observed_counts_are_reconciled_with_the_serialized_arrays() -> None:
 
 def test_coverage_cannot_leave_the_source_timeline() -> None:
     coverage = {
+        "scope_intervals": [[0.0, 10.0]],
         "covered_through_seconds": 4.0,
         "covered_fraction": 0.4,
         "covered_intervals": [[0.0, 4.0]],
@@ -349,12 +370,14 @@ def test_coverage_cannot_leave_the_source_timeline() -> None:
         ({"covered_through_seconds": 5.0, "missing_intervals": [[5.0, 10.0]]},
          "without gaps"),
         ({"units_completed": 2}, "leave at least one"),
+        ({"scope_intervals": [[0.0, 6.0], [5.0, 10.0]]}, "must not overlap"),
     ],
 )
 def test_coverage_ledger_must_be_internally_consistent(
     mutation: dict[str, object], message: str,
 ) -> None:
     coverage = {
+        "scope_intervals": [[0.0, 10.0]],
         "covered_through_seconds": 4.0,
         "covered_fraction": 0.4,
         "covered_intervals": [[0.0, 4.0]],
@@ -365,6 +388,20 @@ def test_coverage_ledger_must_be_internally_consistent(
     }
     with pytest.raises(ResultError, match=message):
         serialize_result(base_result(complete=False, coverage=coverage))
+
+
+def test_coverage_validator_exercises_multiple_disjoint_scopes() -> None:
+    coverage = {
+        "scope_intervals": [[0.0, 4.0], [6.0, 10.0]],
+        "covered_through_seconds": 2.0,
+        "covered_fraction": 0.5,
+        "covered_intervals": [[0.0, 2.0], [6.0, 8.0]],
+        "missing_intervals": [[2.0, 4.0], [8.0, 10.0]],
+        "units_total": 4,
+        "units_completed": 2,
+    }
+    payload = serialize_result(base_result(complete=False, coverage=coverage))
+    assert payload["coverage"] == coverage
 
 
 def test_absent_sentinel_is_not_serialized() -> None:

--- a/tests/test_transcribe_stacks.py
+++ b/tests/test_transcribe_stacks.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import json
-from dataclasses import replace
 from copy import deepcopy
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 from audio_cli import packages as pkg
 from audio_cli.transcribe import stacks
-
 
 EXPECTED = {
     "qwen-1.7b": {

--- a/tests/test_transcribe_transport.py
+++ b/tests/test_transcribe_transport.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+from audio_cli import paths
+from audio_cli.transcribe.stages import qwen as qwen_stage
+from audio_cli.transcribe.transport import StageTransport, SubprocessRunner
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+
+    def run(self, command: list[str]) -> subprocess.CompletedProcess[str]:
+        self.commands.append(command)
+        if command[0] == "ffmpeg":
+            Path(command[-1]).write_bytes(b"wav")
+        else:
+            request = json.loads(Path(command[-2]).read_text())
+            Path(command[-1]).write_text(json.dumps({
+                "units": [{"unit_id": item["unit_id"], "processed": True, "text": "ok"}
+                          for item in request["units"]],
+                "metrics": {"wall_seconds": 1.25, "peak_rss_bytes": 40},
+            }))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+
+def test_decode_writes_one_canonical_pcm_wav_without_targeting_source(tmp_path) -> None:
+    source = tmp_path / "source.m4a"
+    source.write_bytes(b"source")
+    target = tmp_path / "canonical.wav"
+    runner = RecordingRunner()
+    StageTransport(runner).decode(source, target)
+    command = runner.commands[0]
+    assert command[-1] == str(target)
+    assert command[command.index("-ac") + 1] == "1"
+    assert command[command.index("-ar") + 1] == "16000"
+    assert command[command.index("-c:a") + 1] == "pcm_s16le"
+    assert source.read_bytes() == b"source"
+
+
+def test_mlx_stage_uses_provisioned_interpreter_and_absolute_shipped_script(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("AUDIO_PROCESSING_MODEL_CACHE", str(tmp_path / "root"))
+    runner = RecordingRunner()
+    outcome = StageTransport(runner).qwen(
+        backend="qwen3-asr-0.6b-8bit",
+        model=tmp_path / "model",
+        audio=tmp_path / "canonical.wav",
+        units=[{"unit_id": "u0", "start": 0.0, "end": 1.0}],
+        language=None,
+        max_tokens=16_384,
+        batch_size=1,
+        clear_cache_after_every_batch=True,
+        directory=tmp_path,
+    )
+    command = runner.commands[0]
+    assert command[0] == str(paths.env_python("mlx"))
+    assert Path(command[1]).is_absolute()
+    assert Path(command[1]).name == "qwen.py"
+    assert Path(command[2]).name == "asr.request.json"
+    assert Path(command[3]).name == "asr.result.json"
+    assert outcome.peak_rss_bytes == 40
+    request = json.loads((tmp_path / "asr.request.json").read_text(encoding="utf-8"))
+    assert request["batch_size"] == 1
+    assert request["clear_cache_after_every_batch"] is True
+
+
+def test_environment_stage_scripts_do_not_import_core_package() -> None:
+    stages = Path(__file__).parents[1] / "src/audio_cli/transcribe/stages"
+    for path in (stages / "qwen.py", stages / "aligner.py"):
+        source = path.read_text()
+        assert "import audio_cli" not in source
+        assert "from audio_cli" not in source
+
+
+def test_stage_sources_pin_the_measured_private_api_and_aligner_language_rule() -> None:
+    stages = Path(__file__).parents[1] / "src/audio_cli/transcribe/stages"
+    qwen = (stages / "qwen.py").read_text()
+    aligner = (stages / "aligner.py").read_text()
+    assert "model._generate_chunks_batched" in qwen
+    assert 'max_tokens=remaining' in qwen
+    assert "mx.clear_cache()" in qwen
+    assert 'CJK = re.compile(r"[一-鿿]")' in aligner
+    assert '"Chinese" if CJK.search(text) else "English"' in aligner
+    assert 'request.get("language")' not in aligner
+    assert '"words": None' in aligner
+    runner = (
+        Path(__file__).parents[1]
+        / "model_tests/benchmark/run_turn_attributed_mlx_asr.py"
+    ).read_text(encoding="utf-8")
+    assert "group_texts, group_generated, group_prompts, group_processed" in runner
+    assert "texts, generated, prompts, processed = method(" in qwen
+
+
+def test_missing_stage_script_preserves_dispatchable_role_and_backend() -> None:
+    from audio_cli.transcribe.transport import StageFailure
+
+    try:
+        StageTransport._stage_script("does-not-exist", "asr", "qwen3-asr-0.6b-8bit")
+    except StageFailure as exc:
+        assert exc.role == "asr"
+        assert exc.backend == "qwen3-asr-0.6b-8bit"
+    else:
+        raise AssertionError("missing stage script did not fail")
+
+
+def test_qwen_stage_salvages_completed_units_after_mid_generation_error(
+    tmp_path, monkeypatch
+) -> None:
+    class Model:
+        calls = 0
+
+        def parameters(self):
+            return []
+
+        def _generate_chunks_batched(self, clips, **kwargs):
+            self.calls += 1
+            if self.calls == 2:
+                raise RuntimeError("boom after first unit")
+            return ["first"], [3], [2], [True]
+
+    mx = types.ModuleType("mlx.core")
+    mx.eval = lambda value: None
+    mx.synchronize = lambda: None
+    mx.clear_cache = lambda: None
+    mx.get_peak_memory = lambda: 123
+    mlx = types.ModuleType("mlx")
+    mlx.core = mx
+    audio_io = types.ModuleType("mlx_audio.audio_io")
+    audio_io.read = lambda *args, **kwargs: (np.zeros((32_000, 1), dtype=np.float32), 16_000)
+    stt_utils = types.ModuleType("mlx_audio.stt.utils")
+    stt_utils.load_model = lambda *args, **kwargs: Model()
+    sample_utils = types.ModuleType("mlx_lm.sample_utils")
+    sample_utils.make_sampler = lambda **kwargs: object()
+    for name, module in {
+        "mlx": mlx,
+        "mlx.core": mx,
+        "mlx_audio": types.ModuleType("mlx_audio"),
+        "mlx_audio.audio_io": audio_io,
+        "mlx_audio.stt": types.ModuleType("mlx_audio.stt"),
+        "mlx_audio.stt.utils": stt_utils,
+        "mlx_lm": types.ModuleType("mlx_lm"),
+        "mlx_lm.sample_utils": sample_utils,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    request_path = tmp_path / "request.json"
+    result_path = tmp_path / "result.json"
+    request_path.write_text(json.dumps({
+        "model": str(tmp_path / "model"),
+        "audio": str(tmp_path / "audio.wav"),
+        "units": [
+            {"unit_id": "u0", "start": 0.0, "end": 1.0},
+            {"unit_id": "u1", "start": 1.0, "end": 2.0},
+        ],
+        "language": None,
+        "max_tokens": 100,
+        "batch_size": 1,
+        "clear_cache_after_every_batch": True,
+    }), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["qwen.py", str(request_path), str(result_path)])
+    assert qwen_stage.main() == 4
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert result["units"][0]["processed"] is True
+    assert result["units"][1]["processed"] is False
+    assert result["error"]["message"] == "boom after first unit"
+
+
+def test_real_subprocess_runner_streams_stderr_and_samples_child_rss() -> None:
+    progress = io.StringIO()
+    completed = SubprocessRunner(progress).run([
+        sys.executable,
+        "-c",
+        "import sys,time; value=bytearray(1000000); print('working', file=sys.stderr, flush=True); time.sleep(0.1)",
+    ])
+    assert completed.returncode == 0
+    assert completed.stderr == "working\n"
+    assert progress.getvalue() == "working\n"
+    assert completed.peak_rss_bytes is not None
+    assert completed.peak_rss_bytes > 0
+
+
+def test_swift_stage_runs_built_product_offline_without_speaker_prior(tmp_path) -> None:
+    checkout = tmp_path / "fluidaudio"
+    product = checkout / ".build" / "arm64-apple-macosx" / "release" / "fluidaudiocli"
+    product.parent.mkdir(parents=True)
+    product.write_bytes(b"binary")
+
+    class SwiftRunner:
+        def __init__(self):
+            self.command = None
+
+        def run(self, command):
+            self.command = command
+            output = Path(command[command.index("--output") + 1])
+            output.write_text(json.dumps({"segments": []}))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+    runner = SwiftRunner()
+    StageTransport(runner).diarize(
+        checkout=checkout,
+        product="fluidaudiocli",
+        audio=tmp_path / "canonical.wav",
+        config={
+            "threshold": 0.6, "step_ratio": 0.1,
+            "min_segment_duration": 0.0, "batch_size": 32,
+        },
+        overlap=True,
+        directory=tmp_path,
+    )
+    assert runner.command[0] == str(product.resolve())
+    assert runner.command[1:3] == ["process", str(tmp_path / "canonical.wav")]
+    assert runner.command[runner.command.index("--mode") + 1] == "offline"
+    assert "--num-speakers" not in runner.command
+    assert runner.command[-1] == "--overlapping-segments"
+    assert not (tmp_path / "diarizer.request.json").exists()
+    assert runner.command[runner.command.index("--batch-size") + 1] == "32"


### PR DESCRIPTION
Closes #21.

## What changed

- add `audio transcribe run` for `qwen-1.7b` and `qwen-0.6b`
- execute canonical decode, optional FluidAudio/Silero stages, MLX ASR, and optional forced alignment through isolated stage processes
- normalize backend artifacts into the source-timeline result contract, including exact abstention ownership and absence semantics
- publish conforming exit-4 partial results with safe, disjoint resume guidance
- preflight packages/runtimes before decode, stream progress on stderr, and protect explicit, derived, and canonical output paths
- update the command contract, happy path, README, shipped skill, implementation records, and the #22-#24 handoff

## Verification

- `uv run --extra dev pytest -q` — 408 passed
- targeted Ruff gate — passed
- `git diff --check` — passed
- `audio packages verify` — mlx, swift, torch-firered, and torch-vibevoice all `ok`; pinned MLX API hash/signature matched
- live floors-only Qwen 0.6B smoke — 23 segments on the canonical 139.284-second fixture timeline
- fresh sdist and wheel — stage scripts, adapters, and shipped skill references present
- staged-diff credential/PII audit — no findings
- Claude adversarial review loop — converged after twelve numbered passes; final response exactly `CONVERGED`
