### PR TITLE
Remove redundant VAD model option from inspect and enhance

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ uv sync --extra dev
 uv run audio enhance --list-stages --profile product-demo
 ```
 
-When no valid local copy is available, the first VAD use downloads the pinned 2.2 MB Silero VAD 6.2.1 ONNX model from its official repository and verifies its SHA-256 digest. It is the only model this CLI fetches implicitly; `audio packages pull silero-vad` provisions it explicitly instead. The [VAD implementation](src/audio_cli/vad.py) enforces that SHA-256 pin. Set `AUDIO_PROCESSING_VAD_MODEL` or pass `--vad-model` to use a pre-populated copy of that same hash-pinned model; an arbitrary ONNX file is refused rather than run under false 6.2.1 provenance. No PyTorch runtime is required.
+When no valid local copy is available, the first VAD use downloads the pinned 2.2 MB Silero VAD 6.2.1 ONNX model from its official repository and verifies its SHA-256 digest. It is the only model this CLI fetches implicitly; `audio packages pull silero-vad` provisions it explicitly instead. The [VAD implementation](src/audio_cli/vad.py) enforces that SHA-256 pin. Set `AUDIO_PROCESSING_MODEL_CACHE` to select the shared provisioning root, or `AUDIO_PROCESSING_VAD_MODEL` to use a pre-populated copy of that same hash-pinned model outside the cache; an arbitrary ONNX file is refused rather than run under false 6.2.1 provenance. See the [migration guide](docs/vad-model-migration.md) for replacing the removed `--vad-model` option with a command-local environment assignment. No PyTorch runtime is required.
 
 ## Use
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - [Vocabulary](VOCABULARY.md), [transcription contract](TRANSCRIBE_CONTRACT.md), and [happy path](TRANSCRIBE_HAPPY_PATH.md): authoritative names, payloads, and examples.
 - [Environments](ENVIRONMENTS.md): declared model packages, runtimes, and provisioning.
+- [Silero VAD configuration migration](vad-model-migration.md): replace the removed inspection/enhancement `--vad-model` option with shared environment configuration.
 - [Enhancement](enhancement.md), [broadband denoising](dsp/denoise/ALGORITHM.md), and [RNNoise](rnnoise-denoising.md): processing behavior and evidence limits.
 - [CLI feedback](cli-feedback.md), [progress and logs](cli-progress-logging.md), [report comparison](report-comparison.md), and [timing evidence](timing-evidence.md): command feedback, saved evidence, and timeline validation.
 - [Model decisions](model-tests/DECISION_REPORT.md), [findings](model-tests/FINDINGS.md), and [experiments](model-tests/EXPERIMENT_RESULTS.md): research documentation; claims about measured output still require runner or artifact evidence.

--- a/docs/vad-model-migration.md
+++ b/docs/vad-model-migration.md
@@ -1,0 +1,24 @@
+# Silero VAD model configuration
+
+`audio inspect` and `audio enhance` use the same pinned Silero VAD model. Their former `--vad-model` option has been removed: it selected a file location, never an alternative model. Existing invocations that include it now fail with an argument error (exit 2); remove the flag and configure the location through the environment.
+
+For a prepopulated copy outside the managed cache, replace `--vad-model /path/to/silero_vad.onnx` with a command-local environment assignment:
+
+```sh
+AUDIO_PROCESSING_VAD_MODEL=/path/to/silero_vad.onnx audio inspect recording.wav
+AUDIO_PROCESSING_VAD_MODEL=/path/to/silero_vad.onnx audio enhance recording.wav --profile product-demo --output enhanced.wav
+```
+
+The override must contain the exact pinned Silero VAD 6.2.1 ONNX artifact. The [resolver](../src/audio_cli/vad.py) checks its SHA-256 before loading it and refuses a missing or mismatched override. It does not replace a bad override by downloading another file.
+
+To provision the managed copy in advance, use:
+
+```sh
+audio packages pull silero-vad
+audio inspect recording.wav
+audio enhance recording.wav --profile product-demo --output enhanced.wav
+```
+
+`AUDIO_PROCESSING_MODEL_CACHE` selects the shared provisioning root. Set it consistently for provisioning and later commands; the VAD model lives under that root's `models/` directory. `AUDIO_PROCESSING_VAD_MODEL` takes precedence when set. Without an override or a valid managed copy, first VAD use retains the existing pinned download and SHA-256 verification. No source media is modified by model resolution. See [environments](ENVIRONMENTS.md) for provisioning details.
+
+Inspection and enhancement still use VAD. Transcription's separate `--vad` selector and saved-report commands are unchanged.

--- a/model_tests/benchmark/results/2026-09-07-vad-model-option-acceptance.json
+++ b/model_tests/benchmark/results/2026-09-07-vad-model-option-acceptance.json
@@ -1,0 +1,109 @@
+{
+  "date": "2026-09-07",
+  "issue": 64,
+  "candidate_commit": "b5e6a68877476395913fd8aa62f7256fd00a718b",
+  "candidate_worktree": "/Users/fredy/Documents/fred-projects/audio-processing-cli-issue64",
+  "candidate_executable": "/Users/fredy/Documents/fred-projects/audio-processing-cli-issue64/.venv/bin/audio",
+  "candidate_executable_sha256": "519b5063e0c4d1dc05542241beb577885dfcb475f046848ae60abe0499ef49f5",
+  "candidate_version": "0.1.0",
+  "editable_import_verified_before_and_after": true,
+  "candidate_clean_before_and_after_execution": true,
+  "scope": "Remove inspect/enhance --vad-model while preserving shared model configuration, pinned-model validation and full-source functional enhancement",
+  "feature_verdict": "PASS",
+  "delivery_verdict": "PASS",
+  "raw_artifact_root": "tests/artifacts/acceptance/2026-09-07-issue64",
+  "scope_record": "scope.md",
+  "operator_report": "operator-report.md",
+  "development_report": "development-report.md",
+  "implementation": {
+    "targeted_vad_cli_provisioning_docs_architecture_tests_passed": 196,
+    "additional_cli_pipeline_tests_passed": 168,
+    "targeted_tests_skipped": 0,
+    "lint_format": "PASS",
+    "hooks_installed": true,
+    "independent_source_review": "PASS",
+    "model_resolution_or_enhancement_algorithms_changed": false
+  },
+  "acceptance": {
+    "fresh_operators": 1,
+    "context_fork": "none",
+    "operator_cwd": "/tmp/audio-issue64-operator-20260907",
+    "skill_snapshot": "skill-snapshot/audio-cli",
+    "skill_entry_sha256": "9b2a6c9f43d913dfeaf0ae40d13dbf5068bad5f49fd4afec5ce40487db10b2c3",
+    "skill_files_hashed_and_unchanged": 8,
+    "cli_calls": 22,
+    "exit_zero_calls": 18,
+    "predeclared_exit_two_calls": 4,
+    "unexpected_cli_failures": 0,
+    "real_media_inspections": 4,
+    "real_dry_runs": 2,
+    "real_renders": 2,
+    "audio_processing_sequential": true,
+    "operator": "PASS",
+    "protocol": "PASS",
+    "reporting": "PASS",
+    "independent_evidence_review": "PASS",
+    "independent_review_scope": "Parent reviewer read both canonical reports, actual render hashes, original inspections, configuration log, source identity and all four raw refusal stdout/stderr/exit files; no actionable findings",
+    "new_listening_judgment": "NOT REQUIRED",
+    "records": "Exact executable/arguments/environment/cwd logs and raw stdout/stderr/exit files for every operator CLI call; timestamps limited to available native tool records"
+  },
+  "fixture": {
+    "source": "tests/artifacts/media/demo-video-audio-to-improve.mp4",
+    "source_checkout": "/Users/fredy/Documents/fred-projects/audio-processing-cli",
+    "source_bytes_before_and_after": 91066646,
+    "source_sha256_before_and_after": "8af1c6e867f7e5decf770840ba95e66bdd5d98070331599cea45cdad3a9ff003",
+    "source_unchanged": true,
+    "scope": "full_original",
+    "decoded_duration_seconds": 112.405333,
+    "profile": "product-demo",
+    "profile_version": "5",
+    "denoiser": "rnnoise"
+  },
+  "variants": [
+    {
+      "case": "managed",
+      "configuration": "AUDIO_PROCESSING_VAD_MODEL unset; AUDIO_PROCESSING_MODEL_CACHE selects the existing shared root",
+      "delivery": "PASS",
+      "cli_calls": 12,
+      "canonical_render_report": "managed/enhanced.report.json",
+      "render": "managed/enhanced.mp4"
+    },
+    {
+      "case": "override",
+      "configuration": "Command-local AUDIO_PROCESSING_VAD_MODEL selects an exact prepopulated model copy outside the shared cache",
+      "delivery": "PASS",
+      "cli_calls": 6,
+      "canonical_render_report": "override/enhanced.report.json",
+      "render": "override/enhanced.mp4"
+    }
+  ],
+  "equivalence": {
+    "original_inspections_identical": true,
+    "dry_runs_identical": true,
+    "render_report_differing_pointers": ["/output/path"],
+    "delivered_inspection_differing_pointers": ["/source/path"],
+    "render_bytes_identical": true,
+    "render_bytes": 91073983,
+    "render_sha256": "58b1622788f2a31de1a58c1f90125598f13bee446b2601e3e1d0321fa488d0a3",
+    "resolved_operations_sha256": "c35a8cf5759460f2a3129859a3f8d34fdd35d9be4a05cfa0d7a86fa7a15bcd46",
+    "vad_model_sha256": "1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3",
+    "delivered_program": {"integrated_loudness_lufs": -16.02, "true_peak_dbtp": -2.48, "loudness_range_lu": 16.9},
+    "peak_validation": "pass",
+    "timeline_validation": "pass",
+    "timeline_scope": "decoded_audio_duration_only",
+    "duration_delta_ms": 0.0
+  },
+  "negative_cases": [
+    {"case": "inspect_removed_flag", "exit": 2, "stdout_empty": true, "observed": "unrecognized arguments", "verdict": "PASS"},
+    {"case": "enhance_removed_flag", "exit": 2, "stdout_empty": true, "observed": "unrecognized arguments", "verdict": "PASS"},
+    {"case": "inspect_bad_override", "exit": 2, "stdout_empty": true, "observed": "VadError checksum mismatch", "verdict": "PASS"},
+    {"case": "enhance_bad_override", "exit": 2, "stdout_empty": true, "observed": "VadError checksum mismatch", "verdict": "PASS"}
+  ],
+  "optional_observations": [
+    "Intermediate speech-leveling reached its correction bound at -37.382 dBFS versus -30 dBFS target",
+    "Delivered LRA 16.9 LU remains above the 11 LU profile preference",
+    "Nine fixed final program intervals are inside target while five fresh candidates miss a separate relative-level target",
+    "Actual noise reduction, speech preservation, content alignment and A/V sync remain unmeasured"
+  ],
+  "not_required": ["Other transcription and mixed-language matrix rows for this narrow argument change", "ASR", "Visual analysis", "Filler cuts", "Human listening or model-accuracy judgment"]
+}

--- a/src/audio_cli/cli.py
+++ b/src/audio_cli/cli.py
@@ -63,7 +63,7 @@ def _run_inspect(args: argparse.Namespace) -> int:
     # speech detection over it, and refusing the destination afterwards throws all of that away.
     _ensure_writable_target(args.report, force=args.force, label="Report")
     profile = get_profile(args.profile) if args.profile else None
-    detector = SileroOnnxVad(args.vad_model)
+    detector = SileroOnnxVad()
     report = inspect_source(args.input, profile=profile, detector=detector)
     if args.report:
         write_report(args.report, report)
@@ -115,7 +115,7 @@ def _run_enhance(args: argparse.Namespace) -> int:
         duration=duration,
         nyquist_hz=24_000.0,
     )
-    detector = SileroOnnxVad(args.vad_model)
+    detector = SileroOnnxVad()
     with ProgressReporter("enhance") as progress:
         pipeline = EnhancementPipeline(
             profile,

--- a/src/audio_cli/cli_parser.py
+++ b/src/audio_cli/cli_parser.py
@@ -21,7 +21,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     inspect_parser.add_argument("input", type=Path)
     inspect_parser.add_argument("--profile", choices=sorted(PROFILES))
-    inspect_parser.add_argument("--vad-model", type=Path, help="Use a local Silero ONNX model.")
     inspect_parser.add_argument("--report", type=Path, help="Also write the JSON inspection here.")
     inspect_parser.add_argument(
         "--force",
@@ -59,7 +58,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     enhance_parser.add_argument("--list-stages", action="store_true")
     enhance_parser.add_argument("--report", type=Path)
-    enhance_parser.add_argument("--vad-model", type=Path, help="Use a local Silero ONNX model.")
     enhance_parser.add_argument(
         "--allow-enhanced-input",
         action="store_true",

--- a/tests/audio_cli/test_cli.py
+++ b/tests/audio_cli/test_cli.py
@@ -111,7 +111,7 @@ def test_inspect_refuses_an_existing_report_and_replaces_it_with_force(
     assert "pass --force" in message
     assert json.loads(report.read_text()) == {"stale": True}
 
-    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda path: object())
+    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda: object())
     monkeypatch.setattr(
         "audio_cli.cli.inspect_source",
         lambda source, *, profile, detector: {"kind": "audio_inspection", "fresh": True},
@@ -160,7 +160,7 @@ def test_enhance_refuses_existing_targets_and_replaces_them_with_force(
     monkeypatch.setattr(
         "audio_cli.cli.media_summary", lambda path, probe: {"duration_seconds": 4.0}
     )
-    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda path: object())
+    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda: object())
     monkeypatch.setattr("audio_cli.cli.EnhancementPipeline", StubPipeline)
 
     output.write_text("an earlier render")

--- a/tests/audio_cli/test_cli_timing_evidence.py
+++ b/tests/audio_cli/test_cli_timing_evidence.py
@@ -106,7 +106,7 @@ def video_frames(path):
 def test_cli_duration_evidence_does_not_overclaim_content_or_av_sync(
     tmp_path, monkeypatch, capsys, case
 ):
-    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda path: NoSpeech())
+    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda: NoSpeech())
     source, extension = make_source(tmp_path, case)
     original_hash = hash_file(source)
     before = cli(capsys, "inspect", source)
@@ -188,7 +188,7 @@ def test_cli_duration_evidence_does_not_overclaim_content_or_av_sync(
 def test_cli_rejects_shortened_decoded_audio_before_publication(tmp_path, monkeypatch, capsys):
     from audio_cli.pipeline import publication
 
-    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda path: NoSpeech())
+    monkeypatch.setattr("audio_cli.cli.SileroOnnxVad", lambda: NoSpeech())
     source, _ = make_source(tmp_path, "mp3-delay")
     source_hash = hash_file(source)
     real_encode = publication.encode_output

--- a/tests/audio_cli/test_cli_vad_config.py
+++ b/tests/audio_cli/test_cli_vad_config.py
@@ -1,0 +1,137 @@
+"""Both enhancement commands resolve shared VAD configuration before inference.
+
+Small controlled model bytes exercise real hashing and cache publication; only ONNX loading
+and audio processing are doubled. Fresh-agent acceptance covers the real pinned model/media.
+"""
+
+import hashlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from audio_cli import cli, vad
+
+
+@pytest.fixture(params=["inspect", "enhance"])
+def command(request):
+    return request.param
+
+
+def arguments(command, source):
+    args = [command, str(source)]
+    if command == "enhance":
+        args += ["--profile", "product-demo", "--dry-run"]
+    return args
+
+
+@pytest.fixture
+def processing(tmp_path, monkeypatch):
+    source = tmp_path / "source.wav"
+    source.write_bytes(b"original media is never opened by these controlled processing doubles")
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("AUDIO_PROCESSING_MODEL_CACHE", str(cache))
+    monkeypatch.delenv("AUDIO_PROCESSING_VAD_MODEL", raising=False)
+    monkeypatch.setattr(cli, "probe_media", lambda *args: {})
+    monkeypatch.setattr(cli, "media_summary", lambda *args: {"duration_seconds": 2})
+    loaded = []
+
+    def session(path, **kwargs):
+        loaded.append(Path(path))
+        return object()
+
+    def inspect(source, *, profile, detector):
+        return {"model_path": str(detector.model_path)}
+
+    class Pipeline:
+        def __init__(self, profile, *, detector, **kwargs):
+            self.detector = detector
+
+        def run(self, *args, **kwargs):
+            return {"model_path": str(self.detector.model_path)}
+
+    monkeypatch.setattr(vad.ort, "InferenceSession", session)
+    monkeypatch.setattr(cli, "inspect_source", inspect)
+    monkeypatch.setattr(cli, "EnhancementPipeline", Pipeline)
+    return source, cache, loaded
+
+
+@pytest.mark.parametrize("location", ["managed", "override", "bootstrap"])
+def test_shared_configuration_reaches_both_commands(
+    command, location, processing, monkeypatch, capsys
+):
+    source, cache, loaded = processing
+    content = b"controlled model content matching the test pin"
+    monkeypatch.setattr(vad, "MODEL_SHA256", hashlib.sha256(content).hexdigest())
+    target = cache / "models" / vad.MODEL_FILENAME
+    downloads = []
+
+    def download(request, *, timeout):
+        assert location == "bootstrap", "a populated model must not be downloaded"
+        downloads.append(request.full_url)
+        return io.BytesIO(content)
+
+    monkeypatch.setattr(vad.urllib.request, "urlopen", download)
+    if location == "override":
+        target = source.parent / "prepopulated.onnx"
+        monkeypatch.setenv("AUDIO_PROCESSING_VAD_MODEL", str(target))
+    if location != "bootstrap":
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    assert cli.main(arguments(command, source)) == 0
+    assert json.loads(capsys.readouterr().out) == {"model_path": str(target)}
+    assert loaded == [target]
+    assert target.read_bytes() == content
+    assert downloads == ([vad.MODEL_URL] if location == "bootstrap" else [])
+    if location == "override":
+        assert not cache.exists(), "the environment override must precede cache resolution"
+
+
+@pytest.mark.parametrize("location", ["override", "bootstrap"])
+def test_mismatched_model_is_refused_before_loading(
+    command, location, processing, monkeypatch, capsys
+):
+    source, cache, loaded = processing
+    content = b"not the pinned Silero model"
+    if location == "override":
+        override = source.parent / "wrong.onnx"
+        override.write_bytes(content)
+        monkeypatch.setenv("AUDIO_PROCESSING_VAD_MODEL", str(override))
+        monkeypatch.setattr(
+            vad.urllib.request, "urlopen", lambda *a, **k: pytest.fail("no override fallback")
+        )
+    else:
+        monkeypatch.setattr(vad.urllib.request, "urlopen", lambda *a, **k: io.BytesIO(content))
+
+    assert cli.main(arguments(command, source)) == 2
+    stdout, stderr = capsys.readouterr()
+    assert stdout == ""
+    error = json.loads(stderr)["error"]
+    assert error["type"] == "VadError"
+    assert "checksum mismatch" in error["message"]
+    assert loaded == []
+    assert not (cache / "models" / vad.MODEL_FILENAME).exists()
+    if location == "override":
+        assert override.read_bytes() == content
+        assert not cache.exists()
+
+
+@pytest.mark.parametrize("form", ["separate", "equals"])
+def test_removed_vad_option_is_an_argument_error(command, form, monkeypatch, capsys):
+    monkeypatch.setattr(cli, "SileroOnnxVad", lambda: pytest.fail("argument error precedes VAD"))
+    option = ["--vad-model", "model.onnx"] if form == "separate" else ["--vad-model=model.onnx"]
+    with pytest.raises(SystemExit) as raised:
+        cli.main([*arguments(command, "source.wav"), *option])
+    assert raised.value.code == 2
+    stdout, stderr = capsys.readouterr()
+    assert stdout == ""
+    assert "unrecognized arguments: --vad-model" in stderr
+
+
+def test_help_does_not_advertise_removed_option(command, capsys):
+    with pytest.raises(SystemExit) as raised:
+        cli.main([command, "--help"])
+    assert raised.value.code == 0
+    assert "--vad-model" not in capsys.readouterr().out


### PR DESCRIPTION
`inspect` and `enhance` exposed a model-choice flag even though every accepted file must match the same pinned Silero artifact. Remove `--vad-model` and its constructor forwarding; existing invocations now receive an argument error. The migration guide retains managed provisioning, the shared cache root and command-local `AUDIO_PROCESSING_VAD_MODEL` overrides, including checksum validation and the existing pinned bootstrap.

Closes #64. Stack merge order: this PR → #67 (JSON runs) → #68 (root documentation).

Validation: 1,769 tests passed across the combined stack; 17 optional live-filter tests skipped. The lint/format gate passed. Fresh scoped acceptance ran the full original demo through inspect, dry run, render, delivered inspection and saved-report comparison with both managed and override VAD configuration. Both renders have identical hashes; all four removed-flag/checksum refusals behaved as declared. The tracked acceptance record includes scope, hashes, evidence locations and independent review; no new listening-quality claim is made.

[Scoped acceptance record](https://github.com/fyang0507/audio-processing-cli/blob/codex/remove-vad-model/model_tests/benchmark/results/2026-09-07-vad-model-option-acceptance.json).
