### PR TITLE
Refocus audio skill on decisions and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Transcription uses an explicit stack and produces a reusable JSON result for off
 
 ## Install
 
-This section covers operator setup. Audio-processing agents use the installed `audio` command and report setup blockers through its [readiness guidance](skills/audio-cli/references/readiness.md).
+This section covers operator setup. Audio-processing agents use the installed `audio` command and report setup blockers through its [setup and failure guidance](skills/audio-cli/references/failures.md).
 
 Requirements:
 

--- a/model_tests/benchmark/results/2026-09-07-skill-docs-usability.json
+++ b/model_tests/benchmark/results/2026-09-07-skill-docs-usability.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-09-07",
+  "topic": "shipped skill documentation usability",
+  "candidate": {
+    "commit": "115223076ef89399d611dd8c7fdad6712ade8430",
+    "scope": "Working-tree documentation changes plus a frozen complete skill snapshot; no implementation changes",
+    "executable": "/Users/fredy/Documents/fred-projects/audio-processing-cli/.venv/bin/audio",
+    "version": "0.1.0",
+    "binding": "Editable entrypoint and import verified against this checkout's src/audio_cli; see executable-identity.txt",
+    "evidence_root": "tests/artifacts/acceptance/2026-09-07-skill-docs-1152230",
+    "scope_record": "scope.md",
+    "snapshot": "skill",
+    "diff": "candidate.diff",
+    "identity_before": "identity-before.json",
+    "identity_after": "identity-after.json",
+    "skill_snapshot_and_original_identities_unchanged": true
+  },
+  "documentation": {
+    "word_count_basis": "Whitespace-delimited words in every shipped Markdown file, HEAD versus revised working tree",
+    "before_words": 6035,
+    "after_words": 2575,
+    "reduction_percent": 57.3,
+    "enhancement_before_words": 1557,
+    "enhancement_after_words": 374
+  },
+  "original_media": [
+    {
+      "path": "tests/artifacts/media/demo-video-audio-to-improve.mp4",
+      "sha256": "8af1c6e867f7e5decf770840ba95e66bdd5d98070331599cea45cdad3a9ff003",
+      "bytes": 91066646,
+      "unchanged": true
+    },
+    {
+      "path": "tests/artifacts/media/test-sample-multispeaker.m4a",
+      "sha256": "d5579a83d046f12ede2b98e21cc510c98e4015ad16310ef95c389fc2bd6a249c",
+      "bytes": 2331384,
+      "unchanged": true
+    }
+  ],
+  "fresh_operator_cases": [
+    {
+      "case": "method discovery and scoped input",
+      "operator": "/root/operator_methods",
+      "cli_calls": 4,
+      "all_cli_exits_zero": true,
+      "capability_verdict": "PASS",
+      "delivery_verdict": "PASS",
+      "evidence": "methods/plan-and-evidence.md",
+      "adjustment": "methods/adjustments.json",
+      "developer_validation": "Existing parser accepts exactly +3 dB, original interval 42-45 seconds, full band, using recorded source duration",
+      "processing_effect": "NOT REQUIRED"
+    },
+    {
+      "case": "saved-report interpretation",
+      "operator": "/root/operator_reports",
+      "cli_calls": 5,
+      "all_cli_exits_zero": true,
+      "capability_verdict": "PASS",
+      "delivery_verdict": "PASS",
+      "evidence": "reports/findings.md",
+      "inputs": ["inputs/enhanced-report.json", "inputs/delivered-inspect.json"],
+      "developer_validation": "Quoted delivered metrics, intermediate and final limits, fixed/fresh scopes and explicit sync abstention checked against raw artifacts",
+      "listening_quality": "NOT REQUIRED"
+    },
+    {
+      "case": "offline export and unmet-capability assessment",
+      "operator": "/root/operator_exports",
+      "cli_calls": 3,
+      "all_cli_exits_zero": true,
+      "capability_verdict": "PASS",
+      "delivery_verdict": "PASS",
+      "evidence": "exports/result.md",
+      "outputs": ["exports/plain.txt", "exports/plain.md"],
+      "developer_validation": "Every canonical segment remains in order in both native exports; both input JSON hashes unchanged",
+      "separate_saved_timing_requirement": {
+        "artifact": "inputs/timed-request.json",
+        "capability_verdict": "FAIL",
+        "reason": "Recorded word_timestamps abstained; seg_27 has neither word nor segment timing",
+        "timed_export": "NOT REQUIRED",
+        "assessment_verdict": "PASS",
+        "note": "Correct diagnosis of an existing unmet prerequisite is the documentation check; it does not establish successful timed delivery or a new recognition result"
+      },
+      "auxiliary_tooling_issue": "Non-audio inspection attempted unavailable python and exited 127 before any candidate CLI call. Scope clarification confirmed the predeclared stop rule concerns candidate audio failures; operator continued file inspection with an available tool. Preserved in exports/auxiliary-failure.md."
+    }
+  ],
+  "checks": {
+    "pytest": "PASS: 66 tests under tests/docs plus shipped-skill and file-size architecture tests",
+    "skill_quick_validate": "PASS",
+    "pre_commit_all_files": "PASS: Ruff lint/safe fixes and format",
+    "git_diff_check": "PASS",
+    "changed_document_links": "PASS",
+    "original_canonical_and_skill_preservation": "PASS",
+    "independent_review": "PASS: /root/review_overhaul found no blockers after checking the rewritten guidance, proposal sources, links and operator artifacts"
+  },
+  "limits": [
+    "Narrow documentation usability scope was declared before testing; new model runs, processing, provisioning, recovery execution and the full media regression matrix were not required.",
+    "No recognition accuracy, perceptual quality or performance claim is made.",
+    "The skill still supplies adjustment input because public help omits it. Saved-report discovery was usable, but summary help names only enhancement input and navigation outputs required selective JSON reads.",
+    "Private source media, transcripts and raw CLI evidence remain untracked in tests/artifacts."
+  ]
+}

--- a/skills/audio-cli/SKILL.md
+++ b/skills/audio-cli/SKILL.md
@@ -1,38 +1,31 @@
 ---
 name: audio-cli
-description: Measure, enhance, and transcribe local audio or video with the audio CLI; export transcripts and subtitles, apply scoped audio corrections, and manage required model packages. Use for recording diagnosis, speech cleanup, transcription, and subtitle requests.
+description: Measure, enhance, and transcribe local audio or video with the audio CLI; export transcripts and subtitles, apply scoped corrections, and manage required model packages. Use for recording diagnosis, speech cleanup, transcription, and subtitle requests.
 ---
 
 # Audio work with the `audio` CLI
 
-Use only the `audio` CLI for audio processing, inspection, transcription, export, and model management. Use saved JSON for evidence. This skill supplies decisions and interpretation; the CLI's `--help` supplies commands, flags, and defaults.
+Use the `audio` CLI for audio inspection, processing, transcription, export, and model management. Use its live help for syntax and its responses for measurements, limitations, and remedies. This skill supplies the workflow and decisions around those commands.
 
-## Use the command from any directory
+Use the supplied executable consistently, or `audio` from the current directory if none is specified. Use absolute media/output paths across directories. No repository checkout or implementation imports are needed.
 
-Use `audio` from the current working directory. If the task supplies an absolute path to an `audio` executable, use that executable consistently, including for remedies printed as `audio ...`. Use absolute media and output paths when working across directories.
+## Read for the task
 
-Read its help to discover the available surface. `audio doctor` reports the command's path, version, and host readiness. Neither step requires a repository checkout or runtime imports.
-
-If the command is missing, cannot start, or lacks a required operation, follow [references/readiness.md](references/readiness.md) and report the blocker. Do not switch to an alternative audio tool or backend when a CLI result is unsatisfactory.
-
-## Route by the request
-
-| The request | Read before running it |
+| Request | Reference |
 | --- | --- |
-| Diagnose, enhance, or prepare an audio/video recording | [references/enhance-audio.md](references/enhance-audio.md) |
-| Read or compare saved inspection/enhancement reports | [references/enhance-audio.md](references/enhance-audio.md) |
-| Correct a particular region or measured frequency | [references/targeted-fixes.md](references/targeted-fixes.md) |
-| Transcribe original media or export a saved result | [references/transcribe.md](references/transcribe.md) |
-| Prepare packages, check readiness, or reclaim managed disk | [references/model-packages.md](references/model-packages.md) |
-| A command failed | [references/failures.md](references/failures.md) |
+| Diagnose or enhance a recording; choose a treatment | [Enhancement](references/enhance-audio.md) |
+| Correct a particular interval or frequency | [Targeted fixes](references/targeted-fixes.md) |
+| Interpret or compare saved inspection/enhancement reports | [Saved reports](references/saved-reports.md) |
+| Transcribe original media or export saved JSON | [Transcription and export](references/transcribe.md) |
+| Provision, verify, or reclaim packages | [Model packages](references/model-packages.md) |
+| Resolve command setup or a failure | [Failures](references/failures.md) |
 
-Read only the relevant references. Diagnosis or enhancement alone does not require transcription; export of an existing result does not require running models.
+Read only what the task needs. Diagnosis needs no render; enhancement needs no transcription; exporting saved results needs no model run.
 
-## Preserve the evidence
+## Working rules
 
-- **The original media is canonical.** When transcription is requested or needed, save its original-source result before enhancement or reuse the saved result; see [references/transcribe.md](references/transcribe.md). Enhancement is the final media-changing step. Resolve each revision from the original, preserving its timeline, rather than chaining renders. Enhanced-media ASR or VAD checks may differ and never replace the canonical transcript.
-- **Absence is meaningful.** Never fill an omitted measurement, timestamp, or speaker with a null, zero, or inferred value. Preserve the machine JSON unchanged and put interpretation in the reply.
-- **A measurement is not a preference.** Separate report checks from listening evidence. Preserve an approved result rather than chasing every numeric preference.
-- **`abstained` is unresolved.** Seek evidence for a scoped correction instead of forcing larger values. Gain and EQ cannot independently control speech and music that overlap in one track.
-- **Provision through `audio packages pull`.** The sole automatic exception is the small, hash-verified Silero speech-activity model on first use, including inspection or enhancement. Other models and runtimes require explicit provisioning; never hand-download weights, hand-create a runtime, or edit its pins.
-- **Enhancement does not delete fillers.** Canonical means unedited original-source output, not guaranteed verbatim recognition. The CLI makes no editorial or filler-removal decisions; issues #1 and #39 are closed as `NOT_PLANNED`.
+- Preserve the original media and its timeline. Resolve every enhancement revision from the original. When transcription is also needed, save or reuse its original-source JSON first, then enhance last.
+- Keep canonical JSON unchanged; put interpretation in the reply. Never invent missing text, measurements, timing, or speakers. Canonical means unedited original-source output, not guaranteed verbatim recognition.
+- Separate measured results from listening preferences. Preserve an approved result instead of chasing every numeric target. Enhancement makes no editorial or filler-removal decisions by design.
+- Provision models and runtimes only through `audio packages pull`. The sole automatic exception is the small, hash-verified Silero speech-activity model on first use, including inspection/enhancement.
+- Follow actionable CLI remedies within the user's scope. Do not silently change the requested method, stack, capabilities, or deliverables to get a successful exit, or substitute another audio tool.

--- a/skills/audio-cli/references/enhance-audio.md
+++ b/skills/audio-cli/references/enhance-audio.md
@@ -1,74 +1,27 @@
-# Diagnosing and enhancing audio
+# Diagnose and enhance a recording
 
-Use this lane for recording diagnosis, speech cleanup, leveling, and a proxy for machine listening. For a scoped time or frequency correction, also read [targeted-fixes.md](targeted-fixes.md).
+## Choose the treatment
 
-## Work from the original and enhance last
+Choose the profile by destination: `product-demo` for speech and non-overlapping program audio intended for people; `transcription` for a speech proxy intended for machine listening. A proxy never replaces the original-source transcript.
 
-Diagnosis alone needs inspection, not a render. When transcription is requested or needed, save the original-source result before enhancement or reuse its saved result; follow [transcribe.md](transcribe.md). Pure enhancement does not require transcription. The enhancement loop is:
+Automatic treatment covers channel balance, environmental cleanup, voice EQ and dynamics, and program loudness/peak control. `product-demo` also balances detected non-speech program audio against speech. Discover eligible stages with the selected profile's `--list-stages`; retain them unless the request calls for a skip.
 
-1. **Inspect the original.** Read measured facts and the profile's conclusions. Explain them and stop if the user only asked for diagnosis.
-2. **Resolve without rendering.** Read the dry run's operations, predictions, component evaluations, and any adjustment scopes before creating media.
-3. **Render from the original.** Enhancement is the final media-changing step. A revision starts from that same source, not a previous render.
-4. **Verify the delivered file.** Read the emitted report, by default `OUTPUT.report.json`, rather than quoting dry-run predictions as achieved measurements.
+Environmental cleanup includes high-pass/hum filtering and a selectable broadband denoiser. Choose the broadband method before processing:
 
-## Choose by destination
+| Method | When to choose it | Prerequisite or limit |
+| --- | --- | --- |
+| `stationary` | Reference-based cleanup of a steady background; the default when no method is specified | Needs usable noise-only reference intervals; can abstain when that evidence is unavailable or unsuitable |
+| `rnnoise` | Model-guided speech cleanup when a stationary reference is unsuitable, or the user requests it | Explicitly provision `rnnoise-voice` through [model packages](model-packages.md); can alter wanted sound within speech |
 
-`transcription` prepares a speech proxy for machine listening; `product-demo` treats speech and non-overlapping program audio for human listeners. The profile sets eligible stages, targets, and safe bounds. A disabled stage reporting `no_op` / `disabled_by_profile` is expected. Keep eligible stages unless the user asks to skip them; do not skip a guard merely to force a desired number.
+Neither method separates overlapping sources or guarantees intelligibility. A filter applying does not establish that broadband denoising ran. An abstention calls for a decision about the unmet request, not an automatic method switch.
 
-Automatic balancing can miss quiet intended music or machine audio below its detection threshold. A region outside detected speech is not necessarily noise: it may contain wanted program audio, and the activity detector does not know music from a fan. Use user feedback, known event ranges, or other evidence for a scoped correction instead of reclassifying the whole recording.
+For a known quiet interval or measured narrow hum, use [targeted fixes](targeted-fixes.md). Automatic detection cannot decide whether quiet music or machine audio is wanted; use the user's intent and scoped evidence. Gain/EQ cannot independently control sources that overlap in one track.
 
-Gain and EQ affect overlapping speech and music together. Do not promise separate control without separate sources. Broadband suppression is likewise bounded cleanup, not source separation; its own reported operation and evaluation determine whether it ran. A high-pass or hum filter alone is not evidence that broadband noise was suppressed.
+## Inspect → resolve → render → verify
 
-Choose the broadband method before processing and inspect the selected invocation's live help. The stationary method needs usable reference evidence; the optional RNNoise method needs an explicitly provisioned model. Use [model-packages.md](model-packages.md) for that lifecycle. An abstention does not authorize switching methods when the task forbids fallback. Model-guided processing can still alter wanted sounds within speech. Its reported mask bound is not guaranteed delivered noise reduction or preserved intelligibility, and `applied` does not certify either.
+1. Inspect the original with the chosen profile. For diagnosis alone, explain the findings and stop.
+2. Dry-run the selected treatment and any adjustments. Check what will apply, abstain, or remain outside target before rendering.
+3. Render to a distinct destination from the original. Start every revision from that same source.
+4. Read the delivered-file report. Distinguish actual post-encode measurements from predictions; include unresolved treatment limits in the reply. Do not present publication success as proof of preferred sound.
 
-## Read parent and child outcomes
-
-Use `audio report summary` to navigate a saved enhancement report without processing the audio again; read its help for the input and output surface. Start with its compact navigation view to locate delivered program metrics, separate phase/scope groups, and nested unmeasured checks. Follow its report pointers for full measurements and operation details. Repeated evidence values can share a finding index while their occurrences retain different scopes: an indexed-entry count is not a count of delivered failures. A missing measurement phase remains unknown. The summary preserves recorded outcomes and does not certify overall success.
-
-Stages can be `applied`, `no_op`, `skipped`, `abstained`, or `failed`. `applied` means some work ran, not that every goal was met. Read `stages[].component_evaluations[]` for child statuses and reasons: `environment-denoise` can apply a filter while `broadband-denoise` abstains. Quote the actual child outcome and resolved parameters rather than inferring them from the parent.
-
-For source balancing, also read `stages[].final_region_evaluations[]` when present. `bounded_outside_target` means the safe gain bound was reached without attaining that region's numeric target; `abstained_overlap` preserves a region that could not be adjusted independently. The top-level `unresolved[]` collects explicit component abstentions and unmet measured regional or loudness-range targets. Read its scope, status, reason, and `measured_at` when supplied: `predicted_pre_encode` is a prediction and `encoded_output` is the delivered-file check. An empty list does not establish perceptual quality or rule out undetected problems.
-
-Read each navigation outcome count's collection pointer. A stage's `inside_target_regions` count describes its own recorded stage decision, while `final_region_evaluations` is a separate collection. Neither replaces a fresh inspection's rule evaluations or speech reference. Use `by_rule` to separate a named rule's count from the full collection: machine-relative checks exclude the channel and program checks. Unnamed legacy rows remain only in the collection totals. Keep original rule misses, intermediate limits, predictions and delivered measurements separate when explaining remaining targets.
-
-Report these remaining limits even after a successful render. Do not enlarge gains or add a second pass simply to make every row green. An approved listening result remains useful evidence.
-
-When a component supplies `noise_reference_scopes`, read each scope's eligibility or rejection reason with the component's final decision. Locally eligible references can still fail pooled checks; rejected scopes explain abstention without authorizing a fallback tool, model, or stronger correction.
-
-## Measure the file that was delivered
-
-| Report surface | Interpretation |
-| --- | --- |
-| `source`, `engine`, `profile` | original identity, tool/profile version, targets, and safe bounds |
-| `observations`, `regions`, `rule_evaluations` | original measurements, detected scopes, and profile conclusions |
-| `stages`, `adjustments` | resolved operations and their scoped outcomes |
-| `measurements.before`, `.predicted`, `.after` | source measurements, dry-run predictions, and post-encode checks respectively |
-| `resolved_operations_sha256` | identity of the resolved processing plan |
-
-Quote `measurements.after.program_actual.integrated_loudness_lufs`, `.true_peak_dbtp`, and `.loudness_range_lu` for the delivered file. The corresponding `before.program_actual` measures the original; `predicted.program_actual` still describes a simulation despite its field name.
-
-Older reports lack `program_actual`. In their `measurements.after.program` block, `input_i` is the delivered file's integrated loudness in LUFS, `input_tp` its true peak in dBTP, and `input_lra` its loudness range in LU. The names come from measuring that file as input to the analyzer. Raw `output_i`, `output_tp`, and related values describe normalization diagnostics, not the file that was delivered; the legacy fields retain that meaning. Never turn an absent or null measurement into zero.
-
-Check `rendered`, `timeline_verification`, an available `timeline_preserved`, `measurements.after.duration_delta_ms`, and `final_peak_validation` along with the actual after measurements. A dry run has only predictions: `predicted_pass` is not post-encode validation. The CLI enforces its active publication checks; report the actual target/limit and any skipped stage rather than imposing every profile preference as an unconditional acceptance gate. Successful publication does not certify every child target or prove that someone prefers the sound.
-
-## Duration is not alignment evidence
-
-Read `duration_basis` before comparing durations. The outer `source`/`output` durations are probed audio-stream or container metadata; their `decoded_audio` objects describe actual decoded samples. `timeline_verification.scope: decoded_audio_duration_only` and its tolerance qualify `timeline_preserved`: a pass checks decoded length only. Dry runs report `not_run` and omit the boolean. Older reports without this scope checked probed duration only and could mark a dry run true.
-
-For video, compare available `source.timing` and `output.timing` audio/video starts and `primary_audio_start_minus_video_start_seconds`. These describe metadata origins. Read the explicit `content_alignment` and `av_sync` abstentions even when durations or starts match. A changed start, codec delay, or padding does not by itself prove clipping or a content shift; never claim exact sync, add an inferred offset to transcript bounds, or shift timestamps to repair an assumed defect. Report the available evidence and unresolved alignment instead.
-
-## Fixed regions and fresh detection answer different questions
-
-`region_basis` identifies the source timeline, original detection, fixed source regions, and report-local IDs. Before/after regional measurements reuse those original scopes and IDs to show how the same intervals changed. A fresh `inspect` of the enhanced output runs detection again and may split, merge, or reclassify intervals; its region IDs are local to that new analysis. Compare source-timeline intervals, not equal-looking IDs across reports.
-
-Use `audio report compare` for saved reports with compatible identity and timeline evidence. Its compact navigation view starts with actual overlap, ambiguity and unmatched counts; follow the side-specific pointers to their intervals. Pair counts differ from region counts, and ambiguous overlaps have no preferred match. It keeps each report's intervals, measurements, and speech reference separate. A refusal for missing identity or timeline evidence is not permission to guess a link. A matching digest and decoded duration still do not establish content alignment or A/V sync.
-
-Read the comparison's `measurement_scope_comparison`, under `comparison_overview` in navigation. Its speech-reference and non-speech interval findings are independent. A `different` finding means those measured scopes changed; use the original report's fixed before/after checks to describe treatment and the fresh inspection to describe newly detected candidates. Fixed regions inside target and fresh candidates outside target are separate findings: do not substitute their counts for a before/after success rate or treat the fresh finding as proof the fixed verification failed. A `same` finding concerns recorded time coverage only; speech level, measurement phase and evaluation targets can still differ. Absent findings leave scope equality unestablished. Report the remaining measured limits without turning either collection into an overall listening verdict.
-
-ASR wording and VAD or program classification can change after enhancement. That alone is expected, not evidence of corruption or a reason for speculative re-editing. Keep the canonical original transcript, report substantive listening findings and measured limits, and do not require classification invariance. Enhancement preserves time; it does not remove fillers or other words.
-
-## When it refuses
-
-Use [failures.md](failures.md) for the error channel and safe remedy handling. Common domain refusals protect the original input, reject a marked prior render, or require a distinct writable output/report destination. Choose a fresh output when replacement was not requested.
-
-An invalid adjustment belongs in [targeted-fixes.md](targeted-fixes.md). A very short clip can lack an integrated loudness measurement despite a real non-silent peak; preserve that distinction and read the stated remedy instead of describing the signal as silent.
+Use [saved reports](saved-reports.md) when interpreting detailed evidence or comparing results. Seek listening feedback for perceptual judgments, especially for wanted background audio. A numeric miss alone does not justify stronger processing or another pass.

--- a/skills/audio-cli/references/failures.md
+++ b/skills/audio-cli/references/failures.md
@@ -1,25 +1,19 @@
-# Read a failed command
+# Resolve setup and command failures
 
-Keep its exit code, stdout, and stderr separate. Empty stderr is not success, and a nonzero exit does not always mean there is no usable result.
+## Find the evidence
 
-| Command or failure | Where to read it |
-| --- | --- |
-| `packages verify` completed its checks | stdout JSON: `failed[]`, `verified[]`, and `environments`; exit 3 when `failed` is nonempty, often with empty stderr |
-| Package lifecycle failure, or `verify` could not start its checks | stderr JSON under `error` |
-| `inspect` / `enhance` domain failure | stderr JSON under `error`, often just `type` and `message`; adjustment errors may add structured fields |
-| Transcription / export refusal | a bare JSON object on stderr, usually with `code` and `fix`; a shared media error may instead use the `error` envelope |
-| Argument parsing or command startup failure | stderr may be plain text with no JSON; use the selected executable's help or [readiness diagnostics](readiness.md) |
+Keep the command, exit code, stdout, and stderr. Read the result before retrying: `packages verify` reports failed checks on stdout, and `transcribe run` exit 4 can preserve usable partial JSON. A backend failure is not an abstention.
 
-Progress can precede a stderr JSON object. Parse the complete final object, which may span many lines; do not assume the final line is JSON. If no valid object exists, retain the text and exit code instead of inventing fields. A `transcribe run` exit 4 preserves a partial result: follow [transcribe.md](transcribe.md) before retrying. A `transcribe run` exit 1 is a backend failure, not an abstention.
+Progress can precede a multiline JSON refusal on stderr; read the complete final object. Errors may be bare JSON, wrapped in `error`, or plain startup/parser text. Preserve the actual message instead of assuming one universal envelope.
 
-## Decide whether a fix is executable
+If the command cannot start or lacks the required operation, retain the startup evidence or available help. Use `doctor` when it can run to identify host prerequisites. Report missing installation, updates, or host tools to the operator; do not install them or substitute another audio tool. Model-package setup belongs to the [CLI package lifecycle](model-packages.md).
 
-A printed `fix` is guidance, not permission or proof that it fits this task.
+## Apply a scoped remedy
 
-- A concrete command has the actual input, package, and destination needed for this request. Preserve its quoted arguments, but replace its leading `audio` with the selected executable from [SKILL.md](../SKILL.md). Check that it preserves the intended stack, capabilities, source, and outputs unless a change is justified by the user's request.
-- Examples such as `<stack>`, `<input>`, or a sample `meeting.m4a` are not runnable remedies. Reconstruct the invocation from the actual request and live help when the missing values are known; otherwise report what is missing. Do not execute a placeholder or assume an example path names the user's file.
-- A sentence explains a condition; do not execute it as shell text. Do not evaluate a returned string blindly. Downloads, replacement flags, and removal still need to fit the authorized scope.
+Use the CLI's explanation and `fix` rather than maintaining an error-code lookup table. Follow a concrete remedy within the existing task authorization; routine correction does not need renewed approval.
 
-Apply a prescribed repair once when authorized, then recheck the same condition. If the same failure remains, stop that repair loop and report the command, exit, affected package or environment, and unchanged evidence. Do not escalate to repeated downloads, manual cache edits, runtime changes, or reinstalling the user's PATH tool.
+- Replace a remedy's leading `audio` with the selected executable. Preserve its quoting and check the real source, stack, capabilities, packages, and destinations.
+- Fill placeholders from the actual request and live help; sample paths are not the user's media. A sentence is explanatory guidance, not a shell command. Never blindly evaluate returned text.
+- Downloads, replacement, shared-environment repair, and removal must fit the requested scope. A printed fix does not expand it.
 
-`verify` covers the provisioned root, not just the current plan. Match each failed package and environment to the selected plan before deciding what is blocked; an unrelated failure does not make every stack unusable. See [model-packages.md](model-packages.md) for readiness and repair scope.
+After an authorized repair, recheck the same condition once. If the failure is unchanged, stop that loop and report the evidence. Do not escalate to repeated downloads, manual cache/runtime edits, or silently reduced deliverables. Preserve partial transcription results and use [transcription recovery](transcribe.md) for a changed attempt.

--- a/skills/audio-cli/references/model-packages.md
+++ b/skills/audio-cli/references/model-packages.md
@@ -1,42 +1,23 @@
-# Provisioning and reclaiming model packages
+# Provision and reclaim model packages
 
-Use this lane for preparing a stack, understanding download costs, readiness failures, and reclaiming managed disk space. For a transcript request, start with [transcribe.md](transcribe.md). Use the `audio` executable selected in [SKILL.md](../SKILL.md) throughout.
+## Install for the request
 
-## Select only the packages the task needs
+For transcription, start from the concrete plan and pull its missing package IDs. Its suggested pull is scoped to that request. Selecting a whole stack can include optional packages and cost substantially more; use it when preparing the whole stack is intended. Preserve unknown download costs when describing the estimate.
 
-`doctor` reports host dependencies and the provisioning root. `packages list` reports registry state; `packages path` locates managed artifacts. These commands are read-only. A registry `ready` value records provisioning, not a fresh integrity or usability check.
+For RNNoise enhancement, explicitly pull `rnnoise-voice`. All model/runtime provisioning uses `audio packages pull`; never hand-download weights, build a runtime, or edit pins to bypass a refusal. Silero's first-use bootstrap is the sole automatic exception and can exist without a pull receipt.
 
-For a transcription request, read the concrete plan's `packages[]`: `package` is the id, `provisioned` records availability known to planning, and `bytes`, `total_known_download_bytes`, and `unsized_packages` describe download estimates. The conditional top-level `next` is an exact missing-id pull command; it is absent when all packages are provisioned. On an older invocation without `next`, construct the named-id pull from missing `packages[].package` values and live help. Read warnings and retain any unsized cost.
+Keep long-running pulls alive and follow their progress. Silence alone does not establish a hang; do not start a duplicate pull because a tool call timed out. Read blocking warnings even after a successful exit.
 
-Selecting by stack installs everything that stack can use, including optional additions. It can cost much more than the plan's request. Use that only when preparing the whole stack is intended. Do not combine named ids with a stack or transfer transcription's `--want` to `packages pull`; consult the selected invocation's help for accepted selection forms.
+## Check the relevant readiness
 
-`audio packages pull` owns model and runtime provisioning. The sole first-use auto-fetch is the small hash-verified `silero-vad` model, which inspection and enhancement also use. It can exist without a pull receipt, so registry `absent` does not prove its file is missing, and a plan's `auto_fetch` entry does not prove a prior download. Explicit `packages pull silero-vad` is also available. No other model or runtime is fetched implicitly. Never download weights, build a runtime, alter its lock, or delete cache files by hand to work around a refusal.
+Use `doctor` for host readiness, `packages list`/`path` for installed state and locations, and `packages verify` for fresh checks. Registry readiness and a successful doctor call do not establish package integrity or runtime usability.
 
-## Follow progress and check readiness
+Verification covers the managed root. Match failures and environment limitations to the selected request, even at exit zero: unrelated failures do not block every stack or justify repairing unrelated packages. A blocked build toolchain also does not necessarily make an already-built executable unusable.
 
-Multi-gigabyte pulls can outlast a command timeout. Keep the running process and poll it; progress is on stderr and the completed receipt is on stdout. Silence alone is not evidence of a hang. An interrupted pull can resume; do not kill an active one just to start over.
+Follow the actual repair remedy in [failures](failures.md). Environment repair can affect the shared root, so check its scope. Describe the check actually performed; a pinned revision is not a verified content digest.
 
-`pulled_known_bytes` totals known sizes of owned artifacts materialized by this pull, including repairs; `skipped` packages contribute nothing. Read `pulled_known_bytes_note` for its accounting scope. Inspect successful receipts too: a stack pull can exit 0 with `warnings[].blocking: true` for packages it could not prepare. Naming such a package explicitly can instead fail at exit 3.
+## Reclaim only what was requested
 
-`packages verify` emits its check report on **stdout**, including at exit **3**. Read `failed[]` and each failure's `package` or `packages` and `environment`, alongside `verified[]` and `environments`. Match these against the current plan: an unrelated failed package is a separate problem, not proof that this request cannot run. A selected package's failed check or an unusable environment it needs does block it. Preserve that distinction in the reply.
+Use named removal for selected packages; preview a whole-root purge before performing it. Follow the CLI's ownership decisions for shared caches and retained environments. Download estimates, network traffic, and reclaimed disk space are different quantities.
 
-| Environment verdict | Consequence |
-| --- | --- |
-| `ok` | the checks applicable to that environment passed |
-| `drifted` | follow the prescribed repair; a redirected root requires resolving the named path first |
-| `blocked` | an external tool is missing; no `audio` command installs that tool |
-| `absent` | it is not ready; follow an `environment_not_ready` fix for its named dependents |
-
-A zero verify exit does not cancel a `blocked` verdict or a false/unknown runtime diagnostic. Read the reported limitation before promising the selected task can proceed. Conversely, a provisioned built executable can be runnable even when the toolchain used to build it is absent.
-
-Package-file failures generally prescribe `pull --repair` for named packages; environment lock drift prescribes `verify --repair`. The latter can repair across the managed root, so check its scope before running it on a shared installation. Use the actual failure's fix and the safeguards in [failures.md](failures.md), including stopping after an unchanged prescribed repair. Do not repair an unrelated package merely to obtain a globally green report.
-
-Quote the check that passed. A `revision` or `revisions` entry establishes pinned cache identity and required-file checks, not a content digest. A `git_blob_sha1` with `bytes` records a checked single-file Git content identity and size; it is not a publisher-provided SHA256. `digest: "ok"` is the SHA256-pinned file check; `product_digest` is a separate built-product check. `license_declared` is not redistribution clearance; preserve `license_reviewed` and any `license_unreviewed` warning.
-
-## Disk accounting and reclaiming
-
-Trust the root and package `location` / `locations` returned by `path`. Hub weights can live in a cache shared with other tools outside the managed root, so directory size does not establish package completeness. `pulled_known_bytes` uses manifest-declared sizes for owned revisions and recorded local artifact sizes, excluding pre-existing shared revisions, skipped packages, and environment bytes. It is not network bytes or incremental disk usage. `list`'s `total_known_bytes` is cumulative, and teardown's `reclaimed_bytes` is measured after deletion.
-
-Use `remove` for named packages and `purge` for everything this root provisioned, only when that reclamation is requested. Removing one unknown package refuses the whole named selection. Runtime environments remain while other packages need them, and media/transcripts are not teardown targets.
-
-Preview a purge with its dry run. Read `would_remove.hub_revisions`, `would_keep.hub_revisions`, and `reclaimable_known_bytes`; the estimate excludes retained revisions and environment bytes. On a real teardown, read `hub_revisions_deleted`, `hub_revisions_not_found`, `hub_revisions_retained`, and measured `reclaimed_bytes`. Pre-existing or unowned shared weights may be retained, so reclaiming less than the manifest estimate is expected. Do not finish by deleting directories yourself. If uninstalling was requested, reclaim intended managed packages first because their root survives removal of the CLI.
+Do not finish cleanup by deleting cache directories manually. When uninstalling is requested, reclaim intended managed packages first because their root survives CLI removal.

--- a/skills/audio-cli/references/readiness.md
+++ b/skills/audio-cli/references/readiness.md
@@ -1,9 +1,0 @@
-# Check command readiness
-
-Use the `audio` executable selected in [SKILL.md](../SKILL.md) from any directory. Its help establishes which operations are available; `audio doctor` reports the executable path, version, host dependencies, and managed package root. Record these CLI results when command identity or readiness matters. A reported version alone does not identify an unversioned build.
-
-If the command cannot start, retain the attempted command, working directory, exit code, and stderr. Report that CLI setup is blocking the task. If a required operation is missing, retain the available help and doctor result and report the mismatch to the operator.
-
-For missing host dependencies, use the doctor's evidence to name the blocker. CLI installation, updates, and host-tool setup belong to the operator; do not invoke installers, import the implementation, edit environments, or substitute a different audio tool to continue processing.
-
-When the command runs but a model package is missing or needs repair, use the CLI's own package lifecycle within the requested scope; see [model-packages.md](model-packages.md). A successful doctor call alone does not prove that the packages required by a transcription plan are ready.

--- a/skills/audio-cli/references/saved-reports.md
+++ b/skills/audio-cli/references/saved-reports.md
@@ -1,0 +1,21 @@
+# Interpret saved enhancement reports
+
+Use `audio report summary` for one saved inspection/enhancement report and `audio report compare` for compatible reports. Start with compact navigation and follow its pointers only where the question needs more evidence. These commands require no reprocessing; use live help for output choices.
+
+## Answer the user's question
+
+Report what changed, what remains unresolved, and which conclusions still need listening evidence. Keep original measurements, dry-run predictions, intermediate treatment checks, and delivered-file measurements separate. A stage applying or an empty unresolved list does not establish that every component succeeded or that the sound is preferred; inspect child limits relevant to the request.
+
+Use recorded post-encode measurements for the delivered file. In older reports without `program_actual`, the analyzer's `input_i`, `input_tp`, and `input_lra` measure the file it was given; `output_*` describes normalization diagnostics. Do not substitute those diagnostics for delivered measurements.
+
+## Compare like scopes
+
+Before/after regional checks in one enhancement report reuse fixed original intervals. A fresh inspection detects regions again and can split, merge, or reclassify them. Compare source-time intervals, not report-local IDs or raw success counts. Keep each report's speech reference and measured scopes separate; an ambiguous overlap has no preferred match.
+
+Fixed-region improvement and newly detected out-of-target regions can both be true. Neither collection is an overall success rate. A scope-comparison result concerns time coverage, not equality of levels, targets, or sound quality.
+
+## Respect evidence limits
+
+A decoded-duration pass establishes length within the reported tolerance, not content alignment or A/V sync. Matching stream starts do not establish sync either; do not infer an offset or shift transcript times from metadata differences.
+
+Changed ASR wording or activity detection after enhancement alone is not evidence of corruption. Preserve the original-source transcript and distinguish fresh detection from treatment verification. Keep absent measurements unknown; a short clip with no integrated loudness measurement can still have a real non-silent peak.

--- a/skills/audio-cli/references/targeted-fixes.md
+++ b/skills/audio-cli/references/targeted-fixes.md
@@ -1,18 +1,12 @@
-# Fixing one region or one frequency
+# Correct a region or frequency
 
-The lane for *"the music at the end is too quiet"* and *"there's a hum through the whole thing"* — a bounded gain you authorize because you have evidence the automatic profile cannot see. The file format is not in `--help`, so it is here in full.
+Use scoped gain when user feedback, a known event range, or a production requirement identifies a correction automatic treatment cannot resolve. Inspect the original to establish its bounds. A reported hum still needs a measured frequency; do not invent a band from the description alone.
 
-## Earn the authorization first
+Reuse the user's existing authorization for the correction. Do not generalize wanted music or unwanted noise from one recording to another, or increase gains simply to satisfy every numeric target.
 
-Automatic enhancement is deliberately conservative, so a miss is expected rather than a bug. What turns a miss into a fix is evidence from outside the tool's own heuristics: the person told you what they heard, the video shows what the audio should be doing, source metadata or a known event range pins the time, or a production requirement states the target.
+## Adjustment input
 
-Never generalize from one file. Quiet external-speaker music is intentional in one demo and unwanted bleed in the next, and only the person can say which. And never build a frequency correction from intent alone — a hum you were told about but did not measure is a hum you cannot scope.
-
-Work from the canonical original and inspect it so the scope traces to measured facts. If transcription is also requested or needed, retain its original-source result before enhancement. Then resolve without rendering and read the `adjustments` block back: placement, fade, and predicted regional measurements are visible before anything is written. Reuse the user's existing approval for a scoped correction; do not ask again or keep increasing it merely because every numeric preference was not reached.
-
-## The file
-
-Exactly one top-level `adjustments` array. Each item holds exactly `type`, `gain_db`, and `scope`; each scope holds exactly `time` and `frequency`. Unknown keys are rejected rather than ignored, so do not add comments, labels, or ids of your own — the report assigns each adjustment a stable id. The numbers below are examples, not measurements or approved corrections for the current media.
+The adjustment-file format is not supplied by CLI help. Pass a JSON file with exactly this structure; the numbers are examples, not measurements of the current recording:
 
 ```json
 {
@@ -29,90 +23,17 @@ Exactly one top-level `adjustments` array. Each item holds exactly `type`, `gain
 }
 ```
 
-- `type` is `gain`. It is the only type.
-- `gain_db` is a finite number in `[-24, +12]`.
-- `time` is `"all"`, or an object satisfying `0 <= start < end <= duration`.
-- `frequency` is `"all"`, or an object holding exactly `low_hz`, `high_hz`, and `shape`.
-- Frequency bounds satisfy `20 <= low_hz < high_hz < 24000`, whatever the source sample rate.
-- `shape` is `band` or `notch`.
+- `type` is `gain`; `gain_db` is finite and within `[-24, +12]`.
+- `time` is `"all"` or exactly `{"start": seconds, "end": seconds}`, with `0 <= start < end <= duration`.
+- `frequency` is `"all"` or exactly `{"low_hz": 55, "high_hz": 65, "shape": "notch"}`. Bounds satisfy `20 <= low_hz < high_hz < 24000`; `shape` is `band` or `notch`.
+- Keep the shown key sets; do not add labels, comments, or IDs. Multiple corrections are separate entries in the array.
 
-## Placement is derived from scope, not declared
+For a measured narrow hum, use a negative gain and the measured frequency scope; use `time: "all"` only if the correction is warranted throughout.
 
-Where the gain lands in the processing order follows from what you scoped, and the report prints the result as `placement`:
+## Resolve and check
 
-| Scope | `placement` | Meaning |
-| --- | --- | --- |
-| frequency-scoped | `before-voice-enhance` | tonal correction, before speech treatment sees it |
-| full-band, time-scoped | `after-source-balance` | regional level change, after automatic balancing |
-| full-band, full-time | `before-program-loudness` | program-wide level change, before normalization |
+Follow the [enhancement workflow](enhance-audio.md). Dry-run from the original and inspect the resolved scope, placement, fade, and predicted effect before rendering. Placement follows the scope; it is not an input choice.
 
-Time-scoped gains take the boundary fade *inside* the scope you declared. When the audible event has to receive full gain from its first sample to its last, widen the scope into surrounding silence you have verified is silent, then confirm the resolved fade in the report.
+Boundary fades occur inside a time scope. If an event needs full gain throughout, extend the scope only into verified surrounding silence. Loudness and peak control run afterward, so the delivered change may differ from the requested gain.
 
-## Rejection is structured, and nothing is repaired for you
-
-Scopes are treated as untrusted input and validated against the media's real duration before any model loads or anything renders. An invalid file exits **2**, prints an `error` envelope on stderr, and creates neither media nor a report. Values are never clamped, `start` and `end` are never swapped, units are never reinterpreted, and an adjustment is never silently dropped — a wrong scope is worse than no adjustment, so the tool refuses instead of guessing.
-
-| `code` | Cause |
-| --- | --- |
-| `scope_out_of_range` | a time or frequency scope outside the media or the 20–24000 Hz bounds |
-| `gain_out_of_range` | `gain_db` outside `[-24, +12]` |
-| `non_finite_number` | NaN or an infinity, echoed back as `"NaN"` / `"Infinity"` |
-| `invalid_number` | a string, boolean, or null where a number belongs |
-| `invalid_adjustment` | unreadable file, malformed JSON, wrong key set, or a `type` other than `gain` |
-
-The first four name the exact `field`, echo a JSON-safe `provided`, and state the `allowed` range, so the correction is usually mechanical:
-
-```json
-{
-  "error": {
-    "type": "AdjustmentError",
-    "code": "scope_out_of_range",
-    "message": "adjustments[0].scope.time must satisfy 0 <= start < end <= 5.000",
-    "field": "adjustments[0].scope.time",
-    "provided": {"start": 4.0, "end": 6.0},
-    "allowed": {
-      "minimum_start_seconds": 0.0,
-      "maximum_end_seconds": 5.0,
-      "constraint": "start < end"
-    }
-  }
-}
-```
-
-`invalid_adjustment` carries a message only — it is the shape-of-the-file error, so there is no one field to blame. Preserve an abstention when no valid scope can be established.
-
-## Two worked cases
-
-**Quiet intended program.** Inspection did not promote quiet music to non-speech program audio, but the person or the video confirms 42.1–55.8 s is intended playback. Authorize a bounded full-band correction over a slightly wider window, using the extra headroom only where inspection shows silence:
-
-```json
-{
-  "adjustments": [
-    {
-      "type": "gain",
-      "gain_db": 5.0,
-      "scope": {"time": {"start": 42.0, "end": 55.9}, "frequency": "all"}
-    }
-  ]
-}
-```
-
-Then compare the region against the speech and program targets in the report. Do not assume the requested gain survives limiting unchanged — loudness and peak control run afterwards.
-
-**A measured narrow hum.** Correct it without touching unrelated frequencies:
-
-```json
-{
-  "adjustments": [
-    {
-      "type": "gain",
-      "gain_db": -8.0,
-      "scope": {"time": "all", "frequency": {"low_hz": 55, "high_hz": 65, "shape": "notch"}}
-    }
-  ]
-}
-```
-
-## Afterwards
-
-Confirm the report records every adjustment with its id, exact scope, resolved placement, and gain. Recheck loudness, true peak, the regional relationships, and timeline preservation, then have someone listen to the adjusted region *and both of its boundaries* — pumping, boosted room noise, tonal coloration, and limiter interaction all show up at the edges rather than in the middle. Never use a gain to claim independent control of overlapping sources.
+Correct invalid input from the CLI's stated field and allowed bounds. If the evidence cannot establish a valid scope, leave the correction unresolved. After rendering, check the measured effect and obtain listening feedback on the region and both boundaries. Gain/EQ affects all overlapping sources within the selected scope.

--- a/skills/audio-cli/references/transcribe.md
+++ b/skills/audio-cli/references/transcribe.md
@@ -1,54 +1,35 @@
 # Transcribe original media and export saved results
 
-## Save, check, and reuse the canonical result
+## Save once, reuse for delivery
 
-1. Reuse an unchanged saved original-source JSON result when its scope and produced capabilities already meet the request.
-2. Otherwise choose a stack, plan the required capabilities, explicitly provision missing packages, and run recognition on the original media. Save the normalized JSON as the reusable canonical result.
-3. Read its range, coverage, requested-capability outcomes and abstentions before delivery. Processing completion is separate from delivery of requested timing or speakers; a receipt points to the evidence and does not replace it.
-4. Export the requested readable or subtitle deliverables from that saved JSON. Retain it for subsequent exports without rerunning models or rewriting the canonical text. Discover command syntax and controls through live help.
+1. Reuse unchanged original-source JSON when its scope and produced capabilities meet the request.
+2. Otherwise discover stacks, inspect the selected stack's capabilities, and plan the original input with only the capabilities needed. Use live help/catalogs for choices and syntax; a suggested minimal plan may need capabilities added for the user's deliverables.
+3. Provision the plan's missing packages through [model packages](model-packages.md), then run recognition and save canonical JSON. When enhancement is also requested, transcribe first and enhance last.
+4. Read the transcript, requested-capability outcomes, coverage, and abstentions before exporting. Processing completion does not guarantee complete timing, speech coverage, or attribution.
+5. Export readable/subtitle deliverables from that JSON with `audio transcribe export`; retain it for subsequent exports without rerunning models or editing recognized text.
 
-If the task also includes enhancement, transcribe first and enhance last. A later ASR check on an enhanced copy is a separate comparison and does not replace this canonical record.
+Choose based on required output and the catalog's stated limits. Package size and a declared capability do not establish accuracy on new media. For subtitles, request real `word_timestamps`. For speaker labels, request diarization; labels remain anonymous without independent identity evidence.
 
-Canonical identifies the unedited result and its source. It does not guarantee that recognition retained every filler, repetition, repair, or dialect form. `verbatim` expresses a text-fidelity capability; it is not a filler-recall guarantee or a switch that makes omitted words reappear. Do not clean the canonical text yourself or describe absent fillers as deliberate editorial cuts. Editorial and filler-removal decisions are outside the CLI scope; issues #1 and #39 are closed as `NOT_PLANNED`.
+## Decisions that need care
 
-## Choose, plan, and run
+- On Qwen, adding diarization changes recognition input spans and can change the text. Treat independently requested variants as separate results; do not require byte-identical wording or splice them together.
+- Canonical output and `verbatim` do not guarantee filler, repetition, or dialect recall. Do not clean the canonical text or describe omitted words as intentional cuts.
+- Published timing uses the original decoded-audio timeline. Do not pre-clip input for a retry, manually offset bounds, or add container/stream starts. Duration equality does not certify subtitle-to-video sync.
+- Read abstentions even on successful completion. Text can survive unavailable alignment; speaker labels on emitted segments do not establish attribution of all original speech. An empty overlap ledger does not establish no overlap if the plan did not detect it.
+- Never invent word timing from segment/turn extents or source duration. A capability that abstained remains unmet even when other output is useful; explain its affected scope.
 
-Choose the stack and the output needed, not every capability. Use `stacks` to discover the declared choices, `capabilities` to evaluate one for the original input, and `plan` to resolve the request. Read the live catalog's quality limits in their fixture and configuration context; neither package size nor a declared capability establishes accuracy on new media. Native versus derived capabilities affect the extra packages and work the plan requires.
+## Recover without changing the task silently
 
-The catalog's `next` is a concrete floors-only plan command, not a recommendation that its minimal output satisfies the user. Add the capabilities the task needs before planning. Request real `word_timestamps` for subtitles; optional speaker labels remain anonymous unless separate evidence establishes a person's identity or role.
+For partial results, retain the JSON and follow a concrete range-resume remedy against the original. If the run made no progress, repeating the same request is not a remedy. Use [failures](failures.md) for command failures and bounded repairs.
 
-On both Qwen stacks (`qwen-1.7b` and `qwen-0.6b`), requesting diarization changes the audio spans passed to recognition, so the text can differ from a plain transcription of the same original. Treat independently requested variants as separate canonical results; neither establishes ground truth or must preserve the other's text byte for byte. FireRed recognizes speech regions and adds speaker labels afterward. VibeVoice produces native speakers with its transcript. Requesting diarization does not reslice recognition input on either of those stacks.
+When the task permits alignment-boundary recovery, choose a clipping limit from the recorded overrun evidence and live help. Inspect recorded corrections and outcomes afterward. Clipping an estimate is not measuring its true acoustic endpoint, and a larger limit cannot fix missing output or text mismatches.
 
-Planning never provisions. Read `packages`, costs, and warnings. When packages are missing, the plan's conditional `next` names a pull for exactly the missing ids; it is absent when no pull is needed. Apply the selected executable and concrete-command checks in [failures.md](failures.md). For provisioning or verification, read [model-packages.md](model-packages.md); a `provisioned` plan entry is not a fresh integrity check. A selected package failure blocks execution before inference.
+A changed stack or alignment policy is a separate attempt with new result, export, and diagnostic destinations. Preserve the earlier evidence and required scope/capabilities. Check the new result before export; do not splice text, timing, or anonymous speaker labels across attempts. Stop when the authorized recovery is exhausted.
 
-If stack or input is missing, supply the actual missing value and repeat the intended command. Do not choose a different stack, drop the requested capabilities, or substitute an example file merely to turn a refusal into a zero exit.
+## Export prerequisites
 
-## Read what was produced
+SRT/VTT need real word timing; inspect export omissions as well as the produced cues. Timed text/Markdown need supplied segment or word timing for every segment. Follow the CLI's refusal when those prerequisites are unmet; do not manufacture bounds or silently downgrade a required timed deliverable.
 
-Follow host progress separately from raw backend diagnostics. Elapsed time reports that a child is running, not a completion percentage. Preserve the announced logs with the run evidence; warnings alone establish neither failure nor recognition quality. Use the command's exit status, result coverage, and semantic refusal to decide what action is needed.
+Merge only compatible disjoint results through the exporter. Independent VibeVoice runs with native diarization cannot be merged because equal-looking anonymous labels do not establish shared identity. Export them separately or plan the needed scope together.
 
-A concise receipt is a pointer to the saved canonical result, not a substitute for reading its transcript and abstentions. Its `outcomes` copies recorded requested-capability results: `produced` and `abstained` are distinct from processing `complete`, and absent capabilities are not inferred from counts. Check these outcomes before timing-dependent exports, then read canonical abstentions for affected scopes. Read its recorded range before interpreting completion; a completed selected interval does not mean the whole original file was transcribed. Choose durable diagnostic storage when logs must travel with the run evidence; discover the controls through live help.
-
-Published bounds refer to the original source decoded-audio timeline. Plans label their probed duration basis; runs label `source.duration_basis: canonical_decoded_pcm`, whose zero is the first decoded sample. Container duration, stream starts, and the enhancement decoder at a different sample rate can disagree without establishing lost words or an offset. Do not add a probed start to word or segment times, and do not certify subtitle-to-video sync from duration equality. Processing-container extents are not speech or word timings. Keep absent keys absent, and read the abstention ledger even on success. A requested capability may have outcome `abstained` while useful text or other timed spans survive; report its reason and affected scope rather than calling the entire result complete in that sense. An empty overlap ledger does not prove no overlap when the selected plan did not detect it.
-
-In diarized Qwen output, `overlap`, `short_turn`, and `raw_fragment` abstentions mark scopes withheld from recognition, which can have neither transcript text nor a speaker turn. Inspect their original-source bounds alongside `segments`, supplied `words`, `turns`, and `provenance.outcomes` in the saved JSON. A speaker label on every emitted segment does not establish full-source attribution or speech coverage; do not infer a speaker-accuracy or coverage percentage from it.
-
-A bracketed non-speech event can deliberately have no aligned words. Ordinary speech with an `alignment_unavailable` abstention retains its available text; do not fabricate word bounds from its segment extent. A speaker label withheld over ambiguous overlap stays absent. Scope withholding and unavailable alignment can occur with `complete: true`; they do not by themselves mean processing was truncated.
-
-Exit 4 preserves a conforming partial document. Read `complete` and `coverage`, keep the saved result, and evaluate its concrete range-resume fix against the original input. Do not pre-clip or manually offset timestamps. If no progress was made and the fix is a sentence, replaying the same request is not a remedy. Exit 1 is a backend failure and must not be reported as a successful abstention; see [failures.md](failures.md).
-
-## Recover when the task authorizes a changed attempt
-
-For an alignment boundary rejection, read the affected segment and unit, original word bounds, measured overrun and selected limit. If the user permits bounded clipping, choose an explicit limit using that evidence and live help; increasing it permits the CLI to clip a returned estimate to its input unit. Read the recorded corrections as well as capability outcomes afterward. A corrected bound is not a newly measured acoustic endpoint, and a higher limit cannot repair missing provider output, invalid words or text mismatches.
-
-An authorized alternative is a separately chosen stack: check its catalog and plan with the original scope and required capabilities. Changing a recognizer does not necessarily change its timing provider. Keep each attempt's canonical result and diagnostics, use new output paths, and inspect the new transcript, timing, speakers and abstentions before exporting. Neither alternate text nor equal-looking anonymous labels may be spliced into the earlier canonical result. The CLI does not switch models internally; the agent chooses the changed request. Preserve the earlier failure and report what the new attempt actually delivers. Stop when the authorized recovery is exhausted or a failure falls outside it.
-
-## Export without running models again
-
-Export saved JSON through `audio transcribe export` and inspect its live help for format and output controls. Compatible disjoint results can be merged on the original timeline. Independent VibeVoice runs with native diarization cannot be merged: identical anonymous labels across generations are not proof of shared speaker identity. Export those separately or generate the needed scope together.
-
-SRT/VTT require real word timing. Bounded non-speech events may be omitted; bounded ordinary speech may be omitted beside real cues only with a same-bounds `alignment_unavailable` abstention. Unbounded ordinary text refuses subtitle export, as does a nonempty transcript with no real word stream unless it is the supported bounded-event-only case. Do not use container or guessed bounds as a workaround.
-
-Plain text and Markdown remain untimed by default. Opt-in `--timestamps` uses supplied segment bounds, falling back to the real word-stream extent. Every segment must have one of those timing sources or export refuses; it does not silently skip untimed text. Inspect the selected invocation's help before requesting it. Do not synthesize readable timestamps from turns, coverage, source duration, or processing containers.
-
-File output is atomic and protects the input transcript and canonical media even when replacement is requested. Use a distinct destination, and retain the original JSON for future exports. Explain recognition, timing, and coverage limits in the reply without rewriting machine output.
+Use distinct output destinations and explain recognition, timing, and coverage limits in the reply. Keep the canonical JSON unchanged.


### PR DESCRIPTION
The shipped skill buried enhancement choices beneath report-field explanations and repeated information available in CLI help and responses. This revision puts treatment selection and task workflows first, reducing shipped Markdown from 6,035 to 2,575 words.

- Explain profile goals, automatic treatments, and stationary/RNNoise selection before the enhancement workflow.
- Move saved-report interpretation into its own reference and consolidate setup/readiness into failure guidance.
- Remove schema walkthroughs, error catalogs, accounting glossaries, and backend exposition while retaining operational protocols, evidence limits, and the adjustment input format missing from help.

Validation: 66 documentation, shipped-skill packaging/link, and file-size tests passed; skill validation and repository lint/format passed. Three fresh operators completed method discovery/input construction, saved-report interpretation, and offline export/capability assessment. All 12 CLI calls succeeded; original media, canonical JSON, and the frozen skill snapshot remained unchanged. Independent review found no blockers. The compact validation record preserves scope and the auxiliary tooling issue.

Documentation only; no processing or model behavior changed. New model runs and listening judgments were outside the declared usability scope.
